### PR TITLE
Add extras package with loader stubs

### DIFF
--- a/klippy/extras/__init__.py
+++ b/klippy/extras/__init__.py
@@ -1,0 +1,5 @@
+# Package definition for the extras directory
+#
+# Copyright (C) 2018  Kevin O'Connor <kevin@koconnor.net>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.

--- a/klippy/extras/virtual_filament_sensor.py
+++ b/klippy/extras/virtual_filament_sensor.py
@@ -1,0 +1,10 @@
+"""Stub module for a virtual filament sensor."""
+
+class VirtualFilamentSensor:
+    """Minimal placeholder implementation."""
+    def __init__(self, config):
+        self.printer = config.get_printer()
+
+
+def load_config(config):
+    return VirtualFilamentSensor(config)

--- a/klippy/extras/virtual_input_pin.py
+++ b/klippy/extras/virtual_input_pin.py
@@ -1,0 +1,11 @@
+"""Stub module for a virtual input pin."""
+
+class VirtualInputPin:
+    """Minimal placeholder implementation."""
+    def __init__(self, config):
+        self.printer = config.get_printer()
+        self.pin_name = config.get('pin', 'virtual_pin')
+
+
+def load_config(config):
+    return VirtualInputPin(config)


### PR DESCRIPTION
## Summary
- add `klippy/extras/__init__.py` from upstream Klipper
- provide stub extras modules `virtual_filament_sensor` and `virtual_input_pin`

These modules make Klipper extras discoverable so configs using
`virtual_filament_sensor` or `virtual_input_pin` can load without import
errors.

## Testing
- `python3 -m py_compile klippy/extras/*.py`


------
https://chatgpt.com/codex/tasks/task_e_687d90245ddc8326ad63278273811001