### PR TITLE
Fix watcher cleanup for virtual filament sensor

### DIFF
--- a/klippy/extras/virtual_pin.py
+++ b/klippy/extras/virtual_pin.py
@@ -92,6 +92,9 @@ class VirtualInputPin:
     def register_watcher(self, callback):
         self._watchers.add(callback)
 
+    def unregister_watcher(self, callback):
+        self._watchers.discard(callback)
+
     cmd_SET_VIRTUAL_PIN_help = 'Set the value of a virtual input pin'
     def cmd_SET_VIRTUAL_PIN(self, gcmd):
         val = gcmd.get_int('VALUE', 1)
@@ -219,6 +222,9 @@ class VirtualFilamentSensor:
         self.vpin.register_watcher(self._pin_changed)
         self.runout_helper.note_filament_present(self.reactor.monotonic(),
                                                  bool(self.vpin.state))
+
+    def shutdown(self):
+        self.vpin.unregister_watcher(self._pin_changed)
 
     def set_value(self, val):
         self.vpin.set_value(val)

--- a/tests/test_virtual_pin.py
+++ b/tests/test_virtual_pin.py
@@ -163,3 +163,12 @@ def test_gcode_handlers(printer, vpin):
     gcmd = FakeGcmd()
     cmd_query(gcmd)
     assert 'virtual_pin %s: 1' % vpin.name in gcmd.responses[0]
+
+
+def test_sensor_shutdown_clears_watcher(vpin):
+    cfg = FakeConfig(vpin.printer, 'virtual_filament_sensor sensor',
+                     {'pin': vpin.name})
+    sensor = virtual_pin.VirtualFilamentSensor(cfg)
+    assert sensor._pin_changed in vpin._watchers
+    sensor.shutdown()
+    assert sensor._pin_changed not in vpin._watchers


### PR DESCRIPTION
## Summary
- add `unregister_watcher()` to `VirtualInputPin`
- clear watcher from `VirtualFilamentSensor` on shutdown
- test that sensor cleanup removes the callback

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f05d36f808326a4c1ace036210383