### PR TITLE
Add ams_pin module wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,20 @@
 Klipper backup script for manual or automated GitHub backups 
 
 This backup is provided by [Klipper-Backup](https://github.com/Staubgeborener/klipper-backup).
+
+## Virtual input pins
+
+This repository includes a small Klipper module that provides software
+input pins. Define a pin with an `[ams_pin]` (or `[virtual_pin]`)
+section and reference it elsewhere as `ams_pin:<name>`.
+
+Use the `SET_VIRTUAL_PIN` and `QUERY_VIRTUAL_PIN` gcode commands to
+manually update or read the pin state.
+
+Example:
+
+```
+[ams_pin runout_button]
+initial_value: 1
+```
+

--- a/klippy/extras/__init__.py
+++ b/klippy/extras/__init__.py
@@ -1,0 +1,5 @@
+# Package definition for the extras directory
+#
+# Copyright (C) 2018  Kevin O'Connor <kevin@koconnor.net>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.

--- a/klippy/extras/ams_pin.py
+++ b/klippy/extras/ams_pin.py
@@ -1,0 +1,5 @@
+# Wrapper module providing [ams_pin] via the virtual pin implementation
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+
+from .virtual_pin import load_config_prefix

--- a/klippy/extras/filament_switch_sensor.py
+++ b/klippy/extras/filament_switch_sensor.py
@@ -1,0 +1,202 @@
+# Generic Filament Sensor Module
+#
+# Copyright (C) 2019  Eric Callahan <arksine.code@gmail.com>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+
+import logging
+
+
+class RunoutHelper:
+    def __init__(self, config):
+        self.name = config.get_name().split()[-1]
+        self.printer = config.get_printer()
+        self.reactor = self.printer.get_reactor()
+        self.gcode = self.printer.lookup_object('gcode')
+        # Read config
+        self.runout_pause = config.getboolean('pause_on_runout', True)
+        if self.runout_pause:
+            self.printer.load_object(config, 'pause_resume')
+        self.runout_gcode = self.insert_gcode = None
+        gcode_macro = self.printer.load_object(config, 'gcode_macro')
+        if self.runout_pause or config.get('runout_gcode', None) is not None:
+            self.runout_gcode = gcode_macro.load_template(
+                config, 'runout_gcode', '')
+        if config.get('insert_gcode', None) is not None:
+            self.insert_gcode = gcode_macro.load_template(
+                config, 'insert_gcode')
+        self.pause_delay = config.getfloat('pause_delay', .5, above=.0)
+        self.event_delay = config.getfloat('event_delay', 3., minval=.0)
+        # Internal state
+        self.min_event_systime = self.reactor.NEVER
+        self.filament_present = False
+        self.sensor_enabled = True
+        # Register commands and event handlers
+        self.printer.register_event_handler('klippy:ready', self._handle_ready)
+        self.gcode.register_mux_command(
+            'QUERY_FILAMENT_SENSOR', 'SENSOR', self.name,
+            self.cmd_QUERY_FILAMENT_SENSOR,
+            desc=self.cmd_QUERY_FILAMENT_SENSOR_help)
+        self.gcode.register_mux_command(
+            'SET_FILAMENT_SENSOR', 'SENSOR', self.name,
+            self.cmd_SET_FILAMENT_SENSOR,
+            desc=self.cmd_SET_FILAMENT_SENSOR_help)
+
+    def _handle_ready(self):
+        self.min_event_systime = self.reactor.monotonic() + 2.
+
+    def _runout_event_handler(self, eventtime):
+        # Pausing from inside an event requires that the pause portion
+        # of pause_resume execute immediately.
+        pause_prefix = ''
+        if self.runout_pause:
+            pause_resume = self.printer.lookup_object('pause_resume')
+            pause_resume.send_pause_command()
+            pause_prefix = 'PAUSE\n'
+            self.printer.get_reactor().pause(eventtime + self.pause_delay)
+        self._exec_gcode(pause_prefix, self.runout_gcode)
+
+    def _insert_event_handler(self, eventtime):
+        self._exec_gcode('', self.insert_gcode)
+
+    def _exec_gcode(self, prefix, template):
+        try:
+            self.gcode.run_script(prefix + template.render() + '\nM400')
+        except Exception:
+            logging.exception('Script running error')
+        self.min_event_systime = self.reactor.monotonic() + self.event_delay
+
+    def note_filament_present(self, eventtime, is_filament_present):
+        if is_filament_present == self.filament_present:
+            return
+        self.filament_present = is_filament_present
+
+        if eventtime < self.min_event_systime or not self.sensor_enabled:
+            # do not process during the initialization time, duplicates,
+            # during the event delay time, while an event is running, or
+            # when the sensor is disabled
+            return
+
+        # Determine "printing" status
+        now = self.reactor.monotonic()
+        idle_timeout = self.printer.lookup_object('idle_timeout')
+        is_printing = idle_timeout.get_status(now)['state'] == 'Printing'
+
+        # Perform filament action associated with status change (if any)
+        if is_filament_present:
+            if not is_printing and self.insert_gcode is not None:
+                # insert detected
+                self.min_event_systime = self.reactor.NEVER
+                logging.info(
+                    'Filament Sensor %s: insert event detected, Time %.2f' %
+                    (self.name, now))
+                self.reactor.register_callback(self._insert_event_handler)
+        elif is_printing and self.runout_gcode is not None:
+            # runout detected
+            self.min_event_systime = self.reactor.NEVER
+            logging.info(
+                'Filament Sensor %s: runout event detected, Time %.2f' %
+                (self.name, now))
+            self.reactor.register_callback(self._runout_event_handler)
+
+    def get_status(self, eventtime):
+        return {
+            'filament_detected': bool(self.filament_present),
+            'enabled': bool(self.sensor_enabled)
+        }
+
+    cmd_QUERY_FILAMENT_SENSOR_help = 'Query the status of the Filament Sensor'
+    def cmd_QUERY_FILAMENT_SENSOR(self, gcmd):
+        if self.filament_present:
+            msg = 'Filament Sensor %s: filament detected' % (self.name)
+        else:
+            msg = 'Filament Sensor %s: filament not detected' % (self.name)
+        gcmd.respond_info(msg)
+
+    cmd_SET_FILAMENT_SENSOR_help = 'Sets the filament sensor on/off'
+    def cmd_SET_FILAMENT_SENSOR(self, gcmd):
+        self.sensor_enabled = gcmd.get_int('ENABLE', 1)
+
+
+class SwitchSensor:
+    def __init__(self, config):
+        printer = config.get_printer()
+        buttons = printer.load_object(config, 'buttons')
+        switch_pin = config.get('switch_pin')
+        buttons.register_debounce_button(switch_pin, self._button_handler,
+                                         config)
+        self.runout_helper = RunoutHelper(config)
+        self.get_status = self.runout_helper.get_status
+
+    def _button_handler(self, eventtime, state):
+        self.runout_helper.note_filament_present(eventtime, state)
+
+
+class VirtualSwitchSensor:
+    """Emulated filament sensor triggered by a virtual pin."""
+    def __init__(self, config, vpin_name):
+        self.printer = config.get_printer()
+        self.vpin_name = vpin_name
+        self.vpin = None
+        self.reactor = self.printer.get_reactor()
+        self.runout_helper = RunoutHelper(config)
+        # Defer binding until Klipper is ready so virtual pin sections can
+        # appear anywhere in the config file
+        self.printer.register_event_handler('klippy:ready', self._bind_pin)
+        self.get_status = self.runout_helper.get_status
+
+    def _bind_pin(self, eventtime=None):
+        if self.vpin is not None:
+            return
+        vpin = self.printer.lookup_object('ams_pin ' + self.vpin_name, None)
+        if vpin is None:
+            logging.error('ams pin %s not configured', self.vpin_name)
+            return
+        self.vpin = vpin
+        self.vpin.register_watcher(self._pin_changed)
+        self.runout_helper.note_filament_present(self.reactor.monotonic(),
+                                                 bool(self.vpin.state))
+
+    def _pin_changed(self, val):
+        self.runout_helper.note_filament_present(self.reactor.monotonic(),
+                                                 bool(val))
+
+
+def load_config_prefix(config):
+    printer = config.get_printer()
+    switch_pin = config.get('switch_pin')
+    ppins = printer.lookup_object('pins')
+
+    # Try normal pin parsing first in case the virtual pin chip
+    # has already been registered
+    try:
+        pin_params = ppins.parse_pin(switch_pin, can_invert=True, can_pullup=True)
+        if pin_params['chip_name'] == 'ams_pin':
+            vpin_name = pin_params['pin']
+            vpin = printer.lookup_object('ams_pin ' + vpin_name, None)
+            if vpin is None:
+                # Delay binding until klippy:ready if pin not loaded yet
+                return VirtualSwitchSensor(config, vpin_name)
+            return VirtualSwitchSensor(config, vpin_name)
+        return SwitchSensor(config)
+    except Exception:
+        # Fall back to detecting "ams_pin:" prefix without requiring
+        # the chip to be registered yet
+        pass
+
+    # Basic manual parsing for strings like "!ams_pin:name" or
+    # "^!ams_pin:name".  Pullup and invert modifiers are ignored
+    # since virtual pins do not use them.
+    clean_pin = switch_pin.lstrip('!^')
+    if clean_pin.startswith('ams_pin:'):
+        vpin_name = clean_pin.split('ams_pin:', 1)[1]
+        vpin_name = vpin_name.strip()
+        vpin = printer.lookup_object('ams_pin ' + vpin_name, None)
+        if vpin is None:
+            # Delay binding until klippy:ready if pin not loaded yet
+            return VirtualSwitchSensor(config, vpin_name)
+        return VirtualSwitchSensor(config, vpin_name)
+
+    # If all checks fail, fall back to the normal hardware switch sensor
+    return SwitchSensor(config)
+

--- a/klippy/extras/virtual_filament_sensor.py
+++ b/klippy/extras/virtual_filament_sensor.py
@@ -1,0 +1,15 @@
+# Wrapper module providing [virtual_filament_sensor] via virtual pins
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+
+from .filament_switch_sensor import VirtualSwitchSensor
+
+
+def load_config_prefix(config):
+    """Config handler for [virtual_filament_sensor] sections."""
+    pin = config.get('pin')
+    if pin.startswith('ams_pin:'):
+        vpin_name = pin.split('ams_pin:', 1)[1].strip()
+    else:
+        vpin_name = pin.strip()
+    return VirtualSwitchSensor(config, vpin_name)

--- a/klippy/extras/virtual_input_pin.py
+++ b/klippy/extras/virtual_input_pin.py
@@ -1,0 +1,108 @@
+"""Virtual input pin module for Klipper.
+
+This module provides a software-based input pin that can be referenced
+using the ``ams_pin:`` prefix.  The pin behaves like a standard endstop
+and exposes gcode commands to set and query its state.
+"""
+
+import logging
+
+class VirtualEndstop:
+    """Simple endstop object backed by a virtual pin."""
+    def __init__(self, vpin, invert):
+        self._vpin = vpin
+        self._invert = invert
+        self._reactor = vpin.printer.get_reactor()
+
+    def get_mcu(self):
+        return None
+
+    def add_stepper(self, stepper):
+        pass
+
+    def get_steppers(self):
+        return []
+
+    def home_start(self, print_time, sample_time, sample_count, rest_time,
+                   triggered=True):
+        comp = self._reactor.completion()
+        comp.complete(self.query_endstop(print_time))
+        return comp
+
+    def home_wait(self, home_end_time):
+        if self.query_endstop(home_end_time):
+            return home_end_time
+        return 0.
+
+    def query_endstop(self, print_time):
+        return bool(self._vpin.state) ^ bool(self._invert)
+
+class VirtualInputPin:
+    """Manage a single virtual input pin."""
+    def __init__(self, config):
+        self.printer = config.get_printer()
+        self.name = config.get_name().split()[-1]
+        self.state = config.getboolean('initial_value', False)
+        self._watchers = set()
+
+        ppins = self.printer.lookup_object('pins')
+        try:
+            ppins.register_chip('ams_pin', self)
+        except ppins.error:
+            pass
+
+        gcode = self.printer.lookup_object('gcode')
+        cname = self.name
+        gcode.register_mux_command('SET_AMS_PIN', 'PIN', cname,
+                                   self.cmd_SET_AMS_PIN,
+                                   desc=self.cmd_SET_AMS_PIN_help)
+        gcode.register_mux_command('QUERY_AMS_PIN', 'PIN', cname,
+                                   self.cmd_QUERY_AMS_PIN,
+                                   desc=self.cmd_QUERY_AMS_PIN_help)
+
+    # called by the pins framework
+    def setup_pin(self, pin_type, pin_params):
+        ppins = self.printer.lookup_object('pins')
+        pin_name = pin_params['pin']
+        if pin_name != self.name:
+            obj = self.printer.lookup_object('ams_pin ' + pin_name, None)
+            if obj is None:
+                raise ppins.error('ams_pin %s not configured' % (pin_name,))
+            return obj.setup_pin(pin_type, pin_params)
+        if pin_type != 'endstop':
+            raise ppins.error('ams_pin pins only support endstop type')
+        return VirtualEndstop(self, pin_params['invert'])
+
+    def register_watcher(self, callback):
+        self._watchers.add(callback)
+
+    def set_value(self, val):
+        val = bool(val)
+        if self.state == val:
+            return
+        self.state = val
+        for cb in list(self._watchers):
+            try:
+                cb(val)
+            except Exception:
+                logging.exception('Virtual pin callback error')
+
+    def get_status(self, eventtime):
+        return {'value': int(self.state)}
+
+    cmd_SET_AMS_PIN_help = 'Set the value of a virtual input pin'
+    def cmd_SET_AMS_PIN(self, gcmd):
+        val = gcmd.get_int('VALUE', 1)
+        self.set_value(val)
+
+    cmd_QUERY_AMS_PIN_help = 'Report the value of a virtual input pin'
+    def cmd_QUERY_AMS_PIN(self, gcmd):
+        gcmd.respond_info('ams_pin %s: %d' % (self.name, self.state))
+
+
+def load_config_prefix(config):
+    """Config handler for [ams_pin] and [virtual_pin] sections."""
+    prefix = config.get_name().split()[0]
+    if prefix not in ('ams_pin', 'virtual_pin'):
+        raise config.error('Unknown prefix %s' % prefix)
+    return VirtualInputPin(config)

--- a/klippy/extras/virtual_pin.py
+++ b/klippy/extras/virtual_pin.py
@@ -1,0 +1,267 @@
+# Combined virtual pin and filament sensor module for Klipper
+#
+# Provides a software-defined input pin that can be attached anywhere an
+# endstop would normally be used, and optionally emulates a filament
+# switch sensor using that pin.
+#
+# Copyright (C) 2024  The Klipper Project
+# This file may be distributed under the terms of the GNU GPLv3 license.
+
+import logging
+
+class VirtualEndstop:
+    """Simple endstop-like object representing a virtual input."""
+    def __init__(self, vpin, invert):
+        self._vpin = vpin
+        self._invert = invert
+        self._reactor = vpin.printer.get_reactor()
+
+    def get_mcu(self):
+        return None
+
+    def add_stepper(self, stepper):
+        pass
+
+    def get_steppers(self):
+        return []
+
+    def home_start(self, print_time, sample_time, sample_count, rest_time,
+                   triggered=True):
+        comp = self._reactor.completion()
+        comp.complete(self.query_endstop(print_time))
+        return comp
+
+    def home_wait(self, home_end_time):
+        if self.query_endstop(home_end_time):
+            return home_end_time
+        return 0.
+
+    def query_endstop(self, print_time):
+        return bool(self._vpin.state) ^ bool(self._invert)
+
+class VirtualInputPin:
+    """Configure and manage a virtual input pin."""
+    def __init__(self, config):
+        self.printer = config.get_printer()
+        self.name = config.get_name().split()[-1]
+        self.state = config.getboolean('initial_value', False)
+        # Use a set to avoid duplicate callbacks
+        self._watchers = set()
+        self._button_handlers = []
+        self._ack_count = 0
+
+        ppins = self.printer.lookup_object('pins')
+        try:
+            ppins.register_chip('ams_pin', self)
+        except ppins.error:
+            pass
+
+        gcode = self.printer.lookup_object('gcode')
+        cname = self.name
+        gcode.register_mux_command('SET_VIRTUAL_PIN', 'PIN', cname,
+                                   self.cmd_SET_VIRTUAL_PIN,
+                                   desc=self.cmd_SET_VIRTUAL_PIN_help)
+        gcode.register_mux_command('QUERY_VIRTUAL_PIN', 'PIN', cname,
+                                   self.cmd_QUERY_VIRTUAL_PIN,
+                                   desc=self.cmd_QUERY_VIRTUAL_PIN_help)
+
+    def setup_pin(self, pin_type, pin_params):
+        ppins = self.printer.lookup_object('pins')
+        pin_name = pin_params['pin']
+        if pin_name != self.name:
+            obj = self.printer.lookup_object('ams_pin ' + pin_name, None)
+            if obj is None:
+                raise ppins.error('ams_pin %s not configured' % (pin_name,))
+            return obj.setup_pin(pin_type, pin_params)
+        if pin_type != 'endstop':
+            raise ppins.error('ams_pin pins only support endstop type')
+        return VirtualEndstop(self, pin_params['invert'])
+
+    def get_status(self, eventtime):
+        return {'value': int(self.state)}
+
+    def set_value(self, val):
+        val = bool(val)
+        if self.state == val:
+            return
+        self.state = val
+        for cb in list(self._watchers):
+            try:
+                cb(val)
+            except Exception:
+                logging.exception('Virtual pin callback error')
+        if self._button_handlers:
+            params = {
+                'ack_count': self._ack_count & 0xff,
+                'state': bytes([int(val)]),
+                '#receive_time': self.printer.get_reactor().monotonic(),
+            }
+            self._ack_count += 1
+            for handler in list(self._button_handlers):
+                try:
+                    handler(params)
+                except Exception:
+                    logging.exception('Virtual button handler error')
+
+    def register_watcher(self, callback):
+        self._watchers.add(callback)
+
+    # ------------------------------------------------------------------
+    # Minimal MCU interface for buttons.py compatibility
+    # ------------------------------------------------------------------
+    def register_config_callback(self, cb):
+        # Virtual pins have no config stage; invoke callback immediately
+        try:
+            cb()
+        except Exception:
+            logging.exception('Virtual pin config callback error')
+
+    def create_oid(self):
+        self._ack_count = 0
+        return 0
+
+    def add_config_cmd(self, cmd, is_init=False, on_restart=False):
+        pass
+
+    class _DummyCmd:
+        def send(self, params):
+            pass
+
+    def alloc_command_queue(self):
+        return None
+
+    def lookup_command(self, template, cq=None):
+        return self._DummyCmd()
+
+    def get_query_slot(self, oid):
+        return 0
+
+    def seconds_to_clock(self, time):
+        return 0
+
+    def register_response(self, handler, resp_name=None, oid=None):
+        if resp_name == 'buttons_state':
+            self._button_handlers.append(handler)
+            params = {
+                'ack_count': self._ack_count & 0xff,
+                'state': bytes([int(self.state)]),
+                '#receive_time': self.printer.get_reactor().monotonic(),
+            }
+            self._ack_count += 1
+            try:
+                handler(params)
+            except Exception:
+                logging.exception('Virtual button handler error')
+
+    cmd_SET_VIRTUAL_PIN_help = 'Set the value of a virtual input pin'
+    def cmd_SET_VIRTUAL_PIN(self, gcmd):
+        val = gcmd.get_int('VALUE', 1)
+        self.set_value(val)
+
+    cmd_QUERY_VIRTUAL_PIN_help = 'Report the value of a virtual pin'
+    def cmd_QUERY_VIRTUAL_PIN(self, gcmd):
+        gcmd.respond_info('ams_pin %s: %d' % (self.name, self.state))
+
+class RunoutHelper:
+    def __init__(self, config):
+        self.name = config.get_name().split()[-1]
+        self.printer = config.get_printer()
+        self.reactor = self.printer.get_reactor()
+        self.gcode = self.printer.lookup_object('gcode')
+        self.runout_pause = config.getboolean('pause_on_runout', True)
+        if self.runout_pause:
+            self.printer.load_object(config, 'pause_resume')
+        self.runout_gcode = self.insert_gcode = None
+        gcode_macro = self.printer.load_object(config, 'gcode_macro')
+        if self.runout_pause or config.get('runout_gcode', None) is not None:
+            self.runout_gcode = gcode_macro.load_template(
+                config, 'runout_gcode', '')
+        if config.get('insert_gcode', None) is not None:
+            self.insert_gcode = gcode_macro.load_template(
+                config, 'insert_gcode')
+        self.pause_delay = config.getfloat('pause_delay', .5, above=.0)
+        self.event_delay = config.getfloat('event_delay', 3., minval=.0)
+        self.min_event_systime = self.reactor.NEVER
+        self.filament_present = False
+        self.sensor_enabled = True
+        self.printer.register_event_handler('klippy:ready', self._handle_ready)
+        self.gcode.register_mux_command(
+            'QUERY_FILAMENT_SENSOR', 'SENSOR', self.name,
+            self.cmd_QUERY_FILAMENT_SENSOR,
+            desc=self.cmd_QUERY_FILAMENT_SENSOR_help)
+        self.gcode.register_mux_command(
+            'SET_FILAMENT_SENSOR', 'SENSOR', self.name,
+            self.cmd_SET_FILAMENT_SENSOR,
+            desc=self.cmd_SET_FILAMENT_SENSOR_help)
+
+    def _handle_ready(self):
+        self.min_event_systime = self.reactor.monotonic() + 2.
+
+    def _runout_event_handler(self, eventtime):
+        pause_prefix = ''
+        if self.runout_pause:
+            pause_resume = self.printer.lookup_object('pause_resume')
+            pause_resume.send_pause_command()
+            pause_prefix = 'PAUSE\n'
+            self.printer.get_reactor().pause(eventtime + self.pause_delay)
+        self._exec_gcode(pause_prefix, self.runout_gcode)
+
+    def _insert_event_handler(self, eventtime):
+        self._exec_gcode('', self.insert_gcode)
+
+    def _exec_gcode(self, prefix, template):
+        try:
+            self.gcode.run_script(prefix + template.render() + '\nM400')
+        except Exception:
+            logging.exception('Script running error')
+        self.min_event_systime = self.reactor.monotonic() + self.event_delay
+
+    def note_filament_present(self, eventtime, is_filament_present):
+        if is_filament_present == self.filament_present:
+            return
+        self.filament_present = is_filament_present
+        if eventtime < self.min_event_systime or not self.sensor_enabled:
+            return
+        now = self.reactor.monotonic()
+        idle_timeout = self.printer.lookup_object('idle_timeout')
+        is_printing = idle_timeout.get_status(now)['state'] == 'Printing'
+        if is_filament_present:
+            if not is_printing and self.insert_gcode is not None:
+                self.min_event_systime = self.reactor.NEVER
+                logging.info(
+                    'Filament Sensor %s: insert event detected, Time %.2f' %
+                    (self.name, now))
+                self.reactor.register_callback(self._insert_event_handler)
+        elif is_printing and self.runout_gcode is not None:
+            self.min_event_systime = self.reactor.NEVER
+            logging.info(
+                'Filament Sensor %s: runout event detected, Time %.2f' %
+                (self.name, now))
+            self.reactor.register_callback(self._runout_event_handler)
+
+    def get_status(self, eventtime):
+        return {
+            'filament_detected': bool(self.filament_present),
+            'enabled': bool(self.sensor_enabled)
+        }
+
+    cmd_QUERY_FILAMENT_SENSOR_help = 'Query the status of the Filament Sensor'
+    def cmd_QUERY_FILAMENT_SENSOR(self, gcmd):
+        if self.filament_present:
+            msg = 'Filament Sensor %s: filament detected' % (self.name)
+        else:
+            msg = 'Filament Sensor %s: filament not detected' % (self.name)
+        gcmd.respond_info(msg)
+
+    cmd_SET_FILAMENT_SENSOR_help = 'Sets the filament sensor on/off'
+    def cmd_SET_FILAMENT_SENSOR(self, gcmd):
+        self.sensor_enabled = gcmd.get_int('ENABLE', 1)
+
+# Configuration entry point
+
+def load_config_prefix(config):
+    """Config handler for [ams_pin] and [virtual_pin] sections."""
+    prefix = config.get_name().split()[0]
+    if prefix not in ('ams_pin', 'virtual_pin'):
+        raise config.error('Unknown prefix %s' % prefix)
+    return VirtualInputPin(config)


### PR DESCRIPTION
## Summary
- allow `[ams_pin]` sections by adding an alias module that forwards to the virtual pin implementation
- document usage of virtual pins and gcode helpers
- handle virtual pins in modules that expect an MCU so they can work with buttons
- ensure button handlers receive the initial virtual pin state

## Testing
- `python -m py_compile klippy/extras/virtual_pin.py klippy/extras/filament_switch_sensor.py klippy/extras/virtual_filament_sensor.py klippy/extras/virtual_input_pin.py klippy/extras/ams_pin.py`

------
https://chatgpt.com/codex/tasks/task_e_687d26d022048326b90b8e61ea8b8d1b