### PR TITLE
Fix ams_pin lookup to handle multiple pins

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,51 @@
 Klipper backup script for manual or automated GitHub backups 
 
 This backup is provided by [Klipper-Backup](https://github.com/Staubgeborener/klipper-backup).
+
+## Virtual input pins
+
+This repository includes a small Klipper module that provides software
+**input** pins. Each pin behaves as an endstop-style input so other
+modules treat it like any physical input pin.  Define a pin with an
+`[ams_pin]` section and reference it elsewhere as `ams_pin:<name>`.
+
+Use the `SET_AMS_PIN` and `QUERY_AMS_PIN` gcode commands to
+manually update or read the pin state.
+
+If other modules parse pin names before any `[ams_pin]` section is
+encountered (for example `duplicate_pin_override`), add an empty
+`[ams_pins]` section **near the start of the config file** to register the
+`ams_pin` chip before those modules load.
+
+Example:
+
+```
+[ams_pin runout_button]
+initial_value: 1
+```
+
+Use `SET_AMS_PIN PIN=runout_button VALUE=0` to toggle the pin at runtime
+and `QUERY_AMS_PIN PIN=runout_button` to report its current state.
+
+Pin names are matched case-insensitively, so `RUNOUT_BUTTON` and
+`runout_button` refer to the same pin.
+Each pin also registers under its raw section name and with an
+`ams_pin:` prefix, allowing lookups with or without normalization.
+
+### Automatic OAMS lane pins
+
+The `oams_virtual_pins` module can mirror each `[oams <name>]` section in
+`oamsc.cfg` to eight virtual pins named
+`<name>_lane0_prep`, `<name>_lane0_load`, ...,
+`<name>_lane3_prep`, `<name>_lane3_load`.
+These pins update automatically from the `f1s_hes_value` list exported by
+the corresponding OAMS module and may be referenced as
+`ams_pin:<name>_lane#_prep` or `ams_pin:<name>_lane#_load` elsewhere in the configuration. Enable the feature by
+adding a simple section:
+
+```
+[oams_virtual_pins]
+oams_config: oamsc.cfg
+poll_interval: 1.0
+```
+

--- a/klippy/extras/__init__.py
+++ b/klippy/extras/__init__.py
@@ -1,0 +1,5 @@
+# Package definition for the extras directory
+#
+# Copyright (C) 2018  Kevin O'Connor <kevin@koconnor.net>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.

--- a/klippy/extras/ams_pin.py
+++ b/klippy/extras/ams_pin.py
@@ -1,0 +1,331 @@
+"""Software-defined input pins for Klipper.
+
+This module implements the ``ams_pin`` chip which creates virtual input
+pins that behave like endstop-style pins.  Other subsystems can watch
+the pin for state changes just as they would a physical MCU pin.  Each
+``[ams_pin]`` section defines one pin, accessible elsewhere in the
+configuration via ``ams_pin:<name>``.
+
+The pin value may be changed or queried at runtime using the
+``SET_AMS_PIN`` and ``QUERY_AMS_PIN`` gcode commands.
+
+This file previously contained merge conflict markers that caused a
+syntax error.  Those markers have been removed so the module can load
+properly.
+"""
+
+import logging
+
+# ---------------------------------------------------------------------------
+# Chip management helpers
+# ---------------------------------------------------------------------------
+
+CHIP_NAME = "ams_pin"
+
+def _norm(name):
+    """Normalize a pin name for consistent lookups."""
+    return str(name).strip().lower()
+
+
+class AmsPinChip:
+    """Registry for all virtual pins attached to the ``ams_pin`` chip."""
+
+    def __init__(self, printer):
+        self.printer = printer
+        self.pins = {}
+        self._config_callbacks = []
+        self._button_handlers = []
+        self.printer.register_event_handler('klippy:ready',
+                                            self._run_config_callbacks)
+        self._gcode_registered = False
+
+    def register_pin(self, vpin):
+        self._register_gcode()
+        # Expose the pin by its normalized name, raw config suffix,
+        # and with an explicit "ams_pin:" prefix so lookups work no
+        # matter how other modules reference the pin.
+        key = _norm(vpin.name)
+        self.pins[key] = vpin
+        self.pins[vpin.name] = vpin
+        raw = getattr(vpin, 'raw_name', vpin.name)
+        self.pins[_norm(raw)] = vpin
+        self.pins[raw] = vpin
+        self.pins[f'{CHIP_NAME}:{raw}'] = vpin
+        for handler in self._button_handlers:
+            vpin.register_response(handler, 'buttons_state')
+
+    # G-code command registration --------------------------------------------
+    def _register_gcode(self):
+        if self._gcode_registered:
+            return
+        self._gcode_registered = True
+        gcode = self.printer.lookup_object('gcode')
+        gcode.register_command('SET_AMS_PIN', self.cmd_SET_AMS_PIN,
+                               desc='Set the value of an ams_pin')
+        gcode.register_command('QUERY_AMS_PIN', self.cmd_QUERY_AMS_PIN,
+                               desc='Report the value of an ams_pin')
+
+    def cmd_SET_AMS_PIN(self, gcmd):
+        pin_name = gcmd.get('PIN')
+        if pin_name is None:
+            raise gcmd.error('PIN parameter required')
+        pin_name = str(pin_name).strip()
+        if pin_name.lower().startswith(CHIP_NAME + ':'):
+            pin_name = pin_name.split(':', 1)[1]
+        pin_name = _norm(pin_name)
+        val = gcmd.get_int('VALUE', 1)
+        vpin = self.pins.get(pin_name)
+        if vpin is None:
+            raise gcmd.error(f'Unknown {CHIP_NAME} {pin_name}')
+        vpin.set_value(val)
+
+    def cmd_QUERY_AMS_PIN(self, gcmd):
+        pin_name = gcmd.get('PIN')
+        if pin_name is None:
+            raise gcmd.error('PIN parameter required')
+        pin_name = str(pin_name).strip()
+        if pin_name.lower().startswith(CHIP_NAME + ':'):
+            pin_name = pin_name.split(':', 1)[1]
+        pin_name = _norm(pin_name)
+        vpin = self.pins.get(pin_name)
+        if vpin is None:
+            raise gcmd.error(f'Unknown {CHIP_NAME} {pin_name}')
+        gcmd.respond_info(f'{CHIP_NAME} {pin_name}: {int(vpin.state)}')
+
+    def setup_pin(self, pin_type, pin_params):
+        ppins = self.printer.lookup_object("pins")
+        pin_name = _norm(pin_params["pin"])
+        vpin = self.pins.get(pin_name)
+        if vpin is None:
+            raise ppins.error("%s %s not configured" % (CHIP_NAME, pin_name))
+        # Present the virtual pin itself as the MCU object so other modules
+        # can register callbacks directly on it.
+        pin_params["chip"] = vpin
+        pin_params["mcu"] = vpin
+        return vpin.setup_pin(pin_type, pin_params)
+
+    # Minimal MCU interface ----------------------------------------------------
+    def register_config_callback(self, cb):
+        self._config_callbacks.append(cb)
+
+    def _run_config_callbacks(self, eventtime=None):
+        for cb in self._config_callbacks:
+            try:
+                cb()
+            except Exception:
+                logging.exception('Virtual chip config callback error')
+        self._config_callbacks = []
+
+    def create_oid(self):
+        return 0
+
+    def add_config_cmd(self, cmd, is_init=False, on_restart=False):
+        pass
+
+    class _DummyCmd:
+        def send(self, params):
+            pass
+
+    def alloc_command_queue(self):
+        return None
+
+    def lookup_command(self, template, cq=None):
+        return self._DummyCmd()
+
+    def get_query_slot(self, oid):
+        return 0
+
+    def seconds_to_clock(self, time):
+        return 0
+
+    def register_response(self, handler, resp_name=None, oid=None):
+        if resp_name == 'buttons_state':
+            self._button_handlers.append(handler)
+            for pin in self.pins.values():
+                pin.register_response(handler, resp_name, oid)
+
+
+def _ensure_chip(printer):
+    ppins = printer.lookup_object("pins")
+    chip = ppins.chips.get(CHIP_NAME)
+    if chip is None:
+        chip = AmsPinChip(printer)
+        ppins.register_chip(CHIP_NAME, chip)
+        # Expose chip via `printer.ams_pins` for convenience
+        try:
+            setattr(printer, "ams_pins", chip)
+        except Exception:
+            pass
+    return chip
+
+
+class VirtualEndstop:
+    """Simple endstop object backed by a virtual pin."""
+
+    def __init__(self, vpin, invert):
+        self._vpin = vpin
+        self._invert = invert
+        self._reactor = vpin.printer.get_reactor()
+
+    def get_mcu(self):
+        return None
+
+    def add_stepper(self, stepper):
+        pass
+
+    def get_steppers(self):
+        return []
+
+    def home_start(self, print_time, sample_time, sample_count, rest_time,
+                   triggered=True):
+        comp = self._reactor.completion()
+        comp.complete(self.query_endstop(print_time))
+        return comp
+
+    def home_wait(self, home_end_time):
+        if self.query_endstop(home_end_time):
+            return home_end_time
+        return 0.0
+
+    def query_endstop(self, print_time):
+        return bool(self._vpin.state) ^ bool(self._invert)
+
+
+class VirtualInputPin:
+    """Manage a single virtual input pin."""
+
+    def __init__(self, config):
+        self.printer = config.get_printer()
+        raw_name = config.get_name().split()[-1]
+        self.raw_name = raw_name
+        self.name = _norm(raw_name)
+        self.state = config.getboolean("initial_value", False)
+        self._watchers = set()
+        self._button_handlers = []
+        self._ack_count = 0
+        self._config_callbacks = []
+
+        # Defer config callbacks until Klipper is ready
+        self.printer.register_event_handler(
+            "klippy:ready", self._run_config_callbacks
+        )
+
+        chip = _ensure_chip(self.printer)
+        chip.register_pin(self)
+        # Expose under several keys so lookups succeed regardless of
+        # capitalization or if the caller includes the chip prefix.
+        for key in {f'{CHIP_NAME} {self.name}', f'{CHIP_NAME} {self.raw_name}',
+                    f'{CHIP_NAME}:{self.raw_name}'}:
+            try:
+                self.printer.objects[key] = self
+            except Exception:
+                pass
+
+    # Pins framework interface -------------------------------------------------
+    def setup_pin(self, pin_type, pin_params):
+        if pin_type != "endstop":
+            ppins = self.printer.lookup_object("pins")
+            raise ppins.error("%s pins only support endstop type" % CHIP_NAME)
+        return VirtualEndstop(self, pin_params["invert"])
+
+    # Watchers ----------------------------------------------------------------
+    def register_watcher(self, callback):
+        """Register a callback and immediately invoke it with the state."""
+
+        self._watchers.add(callback)
+        try:
+            callback(self.state)
+        except Exception:
+            logging.exception("Virtual pin callback error")
+
+    def set_value(self, val):
+        val = bool(val)
+        if self.state == val:
+            return
+        self.state = val
+        for cb in list(self._watchers):
+            try:
+                cb(val)
+            except Exception:
+                logging.exception("Virtual pin callback error")
+        if self._button_handlers:
+            params = {
+                "ack_count": self._ack_count & 0xFF,
+                "state": bytes([int(val)]),
+                "#receive_time": self.printer.get_reactor().monotonic(),
+            }
+            self._ack_count += 1
+            for handler in list(self._button_handlers):
+                try:
+                    handler(params)
+                except Exception:
+                    logging.exception("Virtual button handler error")
+
+    def get_status(self, eventtime):
+        return {"value": int(self.state)}
+
+    # Minimal MCU interface ----------------------------------------------------
+    def register_config_callback(self, cb):
+        self._config_callbacks.append(cb)
+
+    def _run_config_callbacks(self, eventtime=None):
+        for cb in self._config_callbacks:
+            try:
+                cb()
+            except Exception:
+                logging.exception("Virtual pin config callback error")
+        self._config_callbacks = []
+
+    def create_oid(self):
+        self._ack_count = 0
+        return 0
+
+    def add_config_cmd(self, cmd, is_init=False, on_restart=False):
+        pass
+
+    class _DummyCmd:
+        def send(self, params):
+            pass
+
+    def alloc_command_queue(self):
+        return None
+
+    def lookup_command(self, template, cq=None):
+        return self._DummyCmd()
+
+    def get_query_slot(self, oid):
+        return 0
+
+    def seconds_to_clock(self, time):
+        return 0
+
+    def register_response(self, handler, resp_name=None, oid=None):
+        if resp_name == "buttons_state":
+            self._button_handlers.append(handler)
+            params = {
+                "ack_count": self._ack_count & 0xFF,
+                "state": bytes([int(self.state)]),
+                "#receive_time": self.printer.get_reactor().monotonic(),
+            }
+            self._ack_count += 1
+            try:
+                handler(params)
+            except Exception:
+                logging.exception("Virtual button handler error")
+
+
+
+def load_config_prefix(config):
+    """Config handler for [ams_pin] sections."""
+
+    prefix = config.get_name().split()[0]
+    if prefix != "ams_pin":
+        raise config.error("Unknown prefix %s" % prefix)
+    return VirtualInputPin(config)
+
+
+def load_config(config):
+    """Alias for load_config_prefix for compatibility."""
+
+    return load_config_prefix(config)
+

--- a/klippy/extras/ams_pins.py
+++ b/klippy/extras/ams_pins.py
@@ -1,0 +1,38 @@
+"""Register the ams_pin chip early for other modules.
+
+Add a simple `[ams_pins]` section anywhere in the configuration to
+pre-register the `ams_pin` chip before any other module tries to parse
+pins.  This avoids unknown pin errors when modules look up
+`ams_pin:<name>` before the pin sections load.
+"""
+
+
+def _register_chip(printer):
+    """Register the ams_pin chip on demand."""
+    ppins = printer.lookup_object('pins')
+    if 'ams_pin' in ppins.chips:
+        return
+    # Import lazily to avoid potential circular imports
+    from .ams_pin import AmsPinChip
+    chip = AmsPinChip(printer)
+    ppins.register_chip('ams_pin', chip)
+    try:
+        setattr(printer, 'ams_pins', chip)
+    except Exception:
+        pass
+
+
+def _handle_config(config):
+    """Shared helper for configuration loading."""
+    _register_chip(config.get_printer())
+    return None
+
+
+def load_config(config):
+    """Config handler for a bare `[ams_pins]` section."""
+    return _handle_config(config)
+
+
+def load_config_prefix(config):
+    """Config handler for `[ams_pins <name>]` sections."""
+    return _handle_config(config)

--- a/klippy/extras/filament_switch_sensor.py
+++ b/klippy/extras/filament_switch_sensor.py
@@ -1,0 +1,202 @@
+# Generic Filament Sensor Module
+#
+# Copyright (C) 2019  Eric Callahan <arksine.code@gmail.com>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+
+import logging
+from .ams_pin import _norm
+
+
+class RunoutHelper:
+    def __init__(self, config):
+        self.name = config.get_name().split()[-1]
+        self.printer = config.get_printer()
+        self.reactor = self.printer.get_reactor()
+        self.gcode = self.printer.lookup_object('gcode')
+        # Read config
+        self.runout_pause = config.getboolean('pause_on_runout', True)
+        if self.runout_pause:
+            self.printer.load_object(config, 'pause_resume')
+        self.runout_gcode = self.insert_gcode = None
+        gcode_macro = self.printer.load_object(config, 'gcode_macro')
+        if self.runout_pause or config.get('runout_gcode', None) is not None:
+            self.runout_gcode = gcode_macro.load_template(
+                config, 'runout_gcode', '')
+        if config.get('insert_gcode', None) is not None:
+            self.insert_gcode = gcode_macro.load_template(
+                config, 'insert_gcode')
+        self.pause_delay = config.getfloat('pause_delay', .5, above=.0)
+        self.event_delay = config.getfloat('event_delay', 3., minval=.0)
+        # Internal state
+        self.min_event_systime = self.reactor.NEVER
+        self.filament_present = False
+        self.sensor_enabled = True
+        # Register commands and event handlers
+        self.printer.register_event_handler('klippy:ready', self._handle_ready)
+        self.gcode.register_mux_command(
+            'QUERY_FILAMENT_SENSOR', 'SENSOR', self.name,
+            self.cmd_QUERY_FILAMENT_SENSOR,
+            desc=self.cmd_QUERY_FILAMENT_SENSOR_help)
+        self.gcode.register_mux_command(
+            'SET_FILAMENT_SENSOR', 'SENSOR', self.name,
+            self.cmd_SET_FILAMENT_SENSOR,
+            desc=self.cmd_SET_FILAMENT_SENSOR_help)
+
+    def _handle_ready(self):
+        self.min_event_systime = self.reactor.monotonic() + 2.
+
+    def _runout_event_handler(self, eventtime):
+        # Pausing from inside an event requires that the pause portion
+        # of pause_resume execute immediately.
+        pause_prefix = ''
+        if self.runout_pause:
+            pause_resume = self.printer.lookup_object('pause_resume')
+            pause_resume.send_pause_command()
+            pause_prefix = 'PAUSE\n'
+            self.printer.get_reactor().pause(eventtime + self.pause_delay)
+        self._exec_gcode(pause_prefix, self.runout_gcode)
+
+    def _insert_event_handler(self, eventtime):
+        self._exec_gcode('', self.insert_gcode)
+
+    def _exec_gcode(self, prefix, template):
+        try:
+            self.gcode.run_script(prefix + template.render() + '\nM400')
+        except Exception:
+            logging.exception('Script running error')
+        self.min_event_systime = self.reactor.monotonic() + self.event_delay
+
+    def note_filament_present(self, eventtime, is_filament_present):
+        if is_filament_present == self.filament_present:
+            return
+        self.filament_present = is_filament_present
+
+        if eventtime < self.min_event_systime or not self.sensor_enabled:
+            # do not process during the initialization time, duplicates,
+            # during the event delay time, while an event is running, or
+            # when the sensor is disabled
+            return
+
+        # Determine "printing" status
+        now = self.reactor.monotonic()
+        idle_timeout = self.printer.lookup_object('idle_timeout')
+        is_printing = idle_timeout.get_status(now)['state'] == 'Printing'
+
+        # Perform filament action associated with status change (if any)
+        if is_filament_present:
+            if not is_printing and self.insert_gcode is not None:
+                # insert detected
+                self.min_event_systime = self.reactor.NEVER
+                logging.info(
+                    'Filament Sensor %s: insert event detected, Time %.2f' %
+                    (self.name, now))
+                self.reactor.register_callback(self._insert_event_handler)
+        elif is_printing and self.runout_gcode is not None:
+            # runout detected
+            self.min_event_systime = self.reactor.NEVER
+            logging.info(
+                'Filament Sensor %s: runout event detected, Time %.2f' %
+                (self.name, now))
+            self.reactor.register_callback(self._runout_event_handler)
+
+    def get_status(self, eventtime):
+        return {
+            'filament_detected': bool(self.filament_present),
+            'enabled': bool(self.sensor_enabled)
+        }
+
+    cmd_QUERY_FILAMENT_SENSOR_help = 'Query the status of the Filament Sensor'
+    def cmd_QUERY_FILAMENT_SENSOR(self, gcmd):
+        if self.filament_present:
+            msg = 'Filament Sensor %s: filament detected' % (self.name)
+        else:
+            msg = 'Filament Sensor %s: filament not detected' % (self.name)
+        gcmd.respond_info(msg)
+
+    cmd_SET_FILAMENT_SENSOR_help = 'Sets the filament sensor on/off'
+    def cmd_SET_FILAMENT_SENSOR(self, gcmd):
+        self.sensor_enabled = gcmd.get_int('ENABLE', 1)
+
+
+class SwitchSensor:
+    def __init__(self, config):
+        printer = config.get_printer()
+        buttons = printer.load_object(config, 'buttons')
+        switch_pin = config.get('switch_pin')
+        buttons.register_debounce_button(switch_pin, self._button_handler,
+                                         config)
+        self.runout_helper = RunoutHelper(config)
+        self.get_status = self.runout_helper.get_status
+
+    def _button_handler(self, eventtime, state):
+        self.runout_helper.note_filament_present(eventtime, state)
+
+
+class VirtualSwitchSensor:
+    """Emulated filament sensor triggered by a virtual pin."""
+    def __init__(self, config, vpin_name):
+        self.printer = config.get_printer()
+        self.vpin_name = _norm(vpin_name)
+        self.vpin = None
+        self.reactor = self.printer.get_reactor()
+        self.runout_helper = RunoutHelper(config)
+        # Defer binding until Klipper is ready so virtual pin sections can
+        # appear anywhere in the config file
+        self.printer.register_event_handler('klippy:ready', self._bind_pin)
+        self.get_status = self.runout_helper.get_status
+
+    def _bind_pin(self, eventtime=None):
+        if self.vpin is not None:
+            return
+        vpin = self.printer.lookup_object('ams_pin ' + self.vpin_name, None)
+        if vpin is None:
+            logging.error('ams pin %s not configured', self.vpin_name)
+            return
+        self.vpin = vpin
+        self.vpin.register_watcher(self._pin_changed)
+        self.runout_helper.note_filament_present(self.reactor.monotonic(),
+                                                 bool(self.vpin.state))
+
+    def _pin_changed(self, val):
+        self.runout_helper.note_filament_present(self.reactor.monotonic(),
+                                                 bool(val))
+
+
+def load_config_prefix(config):
+    printer = config.get_printer()
+    switch_pin = config.get('switch_pin')
+    ppins = printer.lookup_object('pins')
+
+    # Try normal pin parsing first in case the virtual pin chip
+    # has already been registered
+    try:
+        pin_params = ppins.parse_pin(switch_pin, can_invert=True, can_pullup=True)
+        if pin_params['chip_name'] == 'ams_pin':
+            vpin_name = _norm(pin_params['pin'])
+            vpin = printer.lookup_object('ams_pin ' + vpin_name, None)
+            if vpin is None:
+                # Delay binding until klippy:ready if pin not loaded yet
+                return VirtualSwitchSensor(config, vpin_name)
+            return VirtualSwitchSensor(config, vpin_name)
+        return SwitchSensor(config)
+    except Exception:
+        # Fall back to detecting "ams_pin:" prefix without requiring
+        # the chip to be registered yet
+        pass
+
+    # Basic manual parsing for strings like "!ams_pin:name" or
+    # "^!ams_pin:name".  Pullup and invert modifiers are ignored
+    # since virtual pins do not use them.
+    clean_pin = switch_pin.lstrip('!^')
+    if clean_pin.startswith('ams_pin:'):
+        vpin_name = _norm(clean_pin.split('ams_pin:', 1)[1])
+        vpin = printer.lookup_object('ams_pin ' + vpin_name, None)
+        if vpin is None:
+            # Delay binding until klippy:ready if pin not loaded yet
+            return VirtualSwitchSensor(config, vpin_name)
+        return VirtualSwitchSensor(config, vpin_name)
+
+    # If all checks fail, fall back to the normal hardware switch sensor
+    return SwitchSensor(config)
+

--- a/klippy/extras/oams_virtual_pins.py
+++ b/klippy/extras/oams_virtual_pins.py
@@ -1,0 +1,99 @@
+# Helper module to mirror OAMS feeder status to virtual pins
+#
+# For each `[oams <name>]` section found in the given configuration file,
+# eight virtual input pins are created: `<name>_lane0_prep`,
+# `<name>_lane0_load`, ... `<name>_lane3_prep`, `<name>_lane3_load`.
+# These pins reflect the real-time value of
+# `printer['oams <name>'].f1s_hes_value` and can be referenced
+# elsewhere as `ams_pin:<name>_lane#_prep` or `ams_pin:<name>_lane#_load`.
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+
+import os, configparser
+from .ams_pin import VirtualInputPin, _norm
+
+class _FakeConfig:
+    def __init__(self, printer, name, initial=False):
+        self._printer = printer
+        self._name = 'ams_pin ' + name
+        self._initial = initial
+    def get_printer(self):
+        return self._printer
+    def get_name(self):
+        return self._name
+    def getboolean(self, option, default=False):
+        if option == 'initial_value':
+            return self._initial
+        return default
+    def error(self, msg):
+        raise configparser.Error(msg)
+
+class OAMSVirtualPins:
+    def __init__(self, config):
+        self.printer = config.get_printer()
+        self.reactor = self.printer.get_reactor()
+        cfgpath = config.get('oams_config', 'oamsc.cfg')
+        if not os.path.isabs(cfgpath):
+            base = None
+            try:
+                start_args = self.printer.get_start_args()
+                if isinstance(start_args, dict):
+                    base = os.path.dirname(start_args.get('config_file', ''))
+                else:
+                    base = os.path.dirname(getattr(start_args, 'config_file', ''))
+            except Exception:
+                base = None
+            if not base:
+                base = '.'
+            cfgpath = os.path.join(base, cfgpath)
+        cp = configparser.ConfigParser(interpolation=None)
+        try:
+            cp.read(cfgpath)
+        except Exception:
+            cp.read_dict({})
+        self.vpins = {}
+        for sec in cp.sections():
+            if not sec.startswith('oams '):
+                continue
+            name = sec.split(None, 1)[1]
+            for i in range(4):
+                for suffix in ('_prep', '_load'):
+                    raw_name = f'{name}_lane{i}{suffix}'
+                    pin_name = _norm(raw_name)
+                    fc = _FakeConfig(self.printer, raw_name)
+                    vpin = VirtualInputPin(fc)
+                    # expose the pin like a normal config object so other
+                    # modules can look it up via printer.lookup_object()
+                    for key in {f'ams_pin {pin_name}', f'ams_pin {raw_name}',
+                                f'ams_pin:{raw_name}'}:
+                        try:
+                            self.printer.objects[key] = vpin
+                        except Exception:
+                            pass
+                    self.vpins[(name, i, suffix)] = vpin
+        self.poll = config.getfloat('poll_interval', 1.0, above=0.05)
+        self.printer.register_event_handler('klippy:ready', self._on_ready)
+
+    def _on_ready(self, eventtime=None):
+        self.reactor.register_timer(self._poll_timer)
+
+    def _poll_timer(self, eventtime):
+        for (name, idx, suffix), vpin in self.vpins.items():
+            obj = self.printer.lookup_object(f'oams {name}', None)
+            if obj is None:
+                continue
+            vals = getattr(obj, 'f1s_hes_value', None)
+            if not isinstance(vals, (list, tuple)):
+                continue
+            if idx < len(vals):
+                vpin.set_value(bool(vals[idx]))
+        return eventtime + self.poll
+
+def load_config(config):
+    """Config handler for a bare `[oams_virtual_pins]` section."""
+    return OAMSVirtualPins(config)
+
+
+def load_config_prefix(config):
+    """Config handler for `[oams_virtual_pins <name>]` sections."""
+    return OAMSVirtualPins(config)

--- a/klippy/extras/virtual_filament_sensor.py
+++ b/klippy/extras/virtual_filament_sensor.py
@@ -1,0 +1,15 @@
+# Wrapper module providing [virtual_filament_sensor] via virtual pins
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+
+from .filament_switch_sensor import VirtualSwitchSensor
+
+
+def load_config_prefix(config):
+    """Config handler for [virtual_filament_sensor] sections."""
+    pin = config.get('pin')
+    if pin.startswith('ams_pin:'):
+        vpin_name = pin.split('ams_pin:', 1)[1].strip()
+    else:
+        vpin_name = pin.strip()
+    return VirtualSwitchSensor(config, vpin_name)

--- a/klippy/extras/virtual_input_pin.py
+++ b/klippy/extras/virtual_input_pin.py
@@ -1,0 +1,8 @@
+"""Legacy wrapper for virtual input pins.
+
+This module simply re-exports the implementation from ``ams_pin.py`` so
+existing configurations referencing ``virtual_input_pin`` continue to
+work.
+"""
+
+from .ams_pin import *

--- a/klippy/extras/virtual_pin.py
+++ b/klippy/extras/virtual_pin.py
@@ -1,0 +1,9 @@
+"""Legacy wrapper for virtual pins and filament sensors.
+
+This module re-exports the implementation from ``ams_pin.py`` and
+``filament_switch_sensor.py`` so existing configurations referencing
+``virtual_pin`` continue to work without modification.
+"""
+
+from .ams_pin import *
+from .filament_switch_sensor import VirtualSwitchSensor as VirtualFilamentSensor


### PR DESCRIPTION
## Summary
- expose each ams_pin under multiple keys including its raw section name
- store oams lane pins using raw names so lookups with different cases work
- document that pins register under raw names and `ams_pin:` prefix

## Testing
- `python -m py_compile klippy/extras/ams_pin.py klippy/extras/ams_pins.py klippy/extras/filament_switch_sensor.py klippy/extras/oams_virtual_pins.py klippy/extras/virtual_filament_sensor.py klippy/extras/virtual_input_pin.py klippy/extras/virtual_pin.py`

------
https://chatgpt.com/codex/tasks/task_e_687d26d022048326b90b8e61ea8b8d1b