### PR TITLE
Create ams virtual input pins

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,53 @@
 Klipper backup script for manual or automated GitHub backups 
 
 This backup is provided by [Klipper-Backup](https://github.com/Staubgeborener/klipper-backup).
+
+## Virtual input pins
+
+This repository includes a small Klipper module that provides software
+**input** pins. Each pin behaves as an endstop-style input so other
+modules treat it like any physical input pin.  Pins register under the
+chip name `ams`, so they are referenced as `ams:<name>` just like a real
+MCU pin.
+
+Use the `SET_AMS_PIN` and `QUERY_AMS_PIN` gcode commands to
+manually update or read the pin state.
+
+If other modules parse pin names before any `[ams_pins]` or `[ams_pin]`
+section is encountered, add an empty `[ams_pins]` section near the start
+of the config file to register the virtual chip before those modules
+load.
+
+Example defining a single pin:
+
+```
+[ams_pin runout_button]
+initial_value: 1
+```
+
+Use `SET_AMS_PIN PIN=runout_button VALUE=0` to toggle the pin at runtime
+and `QUERY_AMS_PIN PIN=runout_button` to report its current state.
+
+Pin names are matched case-insensitively, so `RUNOUT_BUTTON` and
+`runout_button` refer to the same pin.  Pins also register with an
+`ams:` prefix for modules that expect the chip name to be present.
+
+Each pin is stored internally under a single normalized name.  This
+ensures that multiple `[ams_pin]` sections act independently even when
+names differ only by case.
+
+As of this version every pin allocates its own unique OID so subsystems
+like the button handler can treat each virtual pin as a separate MCU
+input.  Button events now include this OID so handlers can distinguish
+between multiple virtual pins.  This fixes issues where only the first
+configured pin responded to changes.
+
+Watcher callbacks attached to an `ams_pin` may accept either both
+`(eventtime, state)`, a single `state` argument, or just the event time.
+The pin detects the callback signature automatically and invokes it
+immediately with the current state when registered.
+
+The optional `[ams_pins]` section automatically creates eight pins
+named `pin1` through `pin8`.  These can be referenced as `ams:pin1`,
+`ams:pin2`, and so on when defining `switch_pin` options.
+

--- a/klippy/extras/__init__.py
+++ b/klippy/extras/__init__.py
@@ -1,0 +1,5 @@
+# Package definition for the extras directory
+#
+# Copyright (C) 2018  Kevin O'Connor <kevin@koconnor.net>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.

--- a/klippy/extras/ams_pin.py
+++ b/klippy/extras/ams_pin.py
@@ -1,0 +1,346 @@
+"""Virtual input pin support for Klipper."""
+
+__all__ = [
+    "VirtualInputPin", "SimpleFilamentSensor", "load_config_prefix",
+    "AmsPins", "load_config", "CHIP_NAME", "_norm",
+]
+
+import logging
+
+CHIP_NAME = "ams"
+
+
+def _norm(name):
+    return str(name).strip().lower()
+
+
+class VirtualPinChip:
+    """Registry and minimal MCU interface for AMS pins."""
+
+    def __init__(self, printer):
+        self.printer = printer
+        self.pins = {}
+        self._next_oid = 0
+        self._config_cbs = []
+        printer.register_event_handler('klippy:ready', self._run_config_cbs)
+        self._register_gcode()
+
+    def _register_gcode(self):
+        gcode = self.printer.lookup_object('gcode')
+        gcode.register_command('SET_AMS_PIN', self.cmd_SET_AMS_PIN,
+                               desc='Set the value of a virtual input pin')
+        gcode.register_command('QUERY_AMS_PIN', self.cmd_QUERY_AMS_PIN,
+                               desc='Report the value of a virtual input pin')
+
+    def cmd_SET_AMS_PIN(self, gcmd):
+        name = _norm(gcmd.get('PIN'))
+        val = gcmd.get_int('VALUE', 1)
+        vpin = self.pins.get(name)
+        if vpin is None:
+            raise gcmd.error(f'AMS pin {name} not configured')
+        vpin.set_value(val)
+
+    def cmd_QUERY_AMS_PIN(self, gcmd):
+        name = _norm(gcmd.get('PIN'))
+        vpin = self.pins.get(name)
+        if vpin is None:
+            raise gcmd.error(f'AMS pin {name} not configured')
+        gcmd.respond_info(f'{name}: {int(vpin.state)}')
+
+    def setup_pin(self, pin_type, pin_params):
+        ppins = self.printer.lookup_object('pins')
+        if pin_type != 'endstop':
+            raise ppins.error('ams pins only support endstop type')
+        name = _norm(pin_params['pin'])
+        vpin = self.pins.get(name)
+        if vpin is None:
+            raise ppins.error(f'ams pin {name} not configured')
+        pin_params['chip'] = vpin
+        pin_params['mcu'] = vpin
+        return vpin.setup_pin(pin_type, pin_params)
+
+    def register_pin(self, vpin):
+        key = _norm(vpin.name)
+        if key in self.pins:
+            logging.warning('Duplicate AMS pin %s ignored', vpin.name)
+            return
+        self.pins[key] = vpin
+
+    # minimal MCU methods -------------------------------------------------
+    def register_config_callback(self, cb):
+        self._config_cbs.append(cb)
+
+    def _run_config_cbs(self, eventtime=None):
+        for cb in self._config_cbs:
+            try:
+                cb()
+            except Exception:
+                logging.exception('Virtual pin config callback error')
+        self._config_cbs = []
+
+    def create_oid(self):
+        oid = self._next_oid
+        self._next_oid += 1
+        return oid
+
+    def add_config_cmd(self, *args, **kwargs):
+        pass
+
+    class _DummyCmd:
+        def send(self, params):
+            pass
+
+    def alloc_command_queue(self):
+        return None
+
+    def lookup_command(self, template, cq=None):
+        return self._DummyCmd()
+
+    def get_query_slot(self, oid):
+        return 0
+
+    def seconds_to_clock(self, time):
+        return 0
+
+    def register_response(self, handler, resp_name=None, oid=None):
+        pass
+
+
+def _ensure_chip(printer):
+    ppins = printer.lookup_object('pins')
+    chip = ppins.chips.get(CHIP_NAME)
+    if chip is None:
+        chip = VirtualPinChip(printer)
+        ppins.register_chip(CHIP_NAME, chip)
+        # Also register under "ams_pin" for legacy configs
+        if 'ams_pin' not in ppins.chips:
+            ppins.register_chip('ams_pin', chip)
+    return chip
+
+
+class VirtualEndstop:
+    def __init__(self, vpin, invert):
+        self._vpin = vpin
+        self._invert = invert
+        self._reactor = vpin.printer.get_reactor()
+
+    def get_mcu(self):
+        return self._vpin
+
+    def add_stepper(self, stepper):
+        pass
+
+    def get_steppers(self):
+        return []
+
+    def home_start(self, print_time, sample_time, sample_count, rest_time, triggered=True):
+        comp = self._reactor.completion()
+        comp.complete(self.query_endstop(print_time))
+        return comp
+
+    def home_wait(self, home_end_time):
+        if self.query_endstop(home_end_time):
+            return home_end_time
+        return 0.
+
+    def query_endstop(self, print_time):
+        return bool(self._vpin.state) ^ bool(self._invert)
+
+
+class VirtualInputPin:
+    """Single software-defined input pin."""
+
+    def __init__(self, config=None, *, printer=None, name=None, initial_value=False):
+        if config is not None:
+            printer = config.get_printer()
+            name = config.get_name().split()[-1]
+            initial_value = config.getboolean('initial_value', False)
+        self.printer = printer
+        self.name = name
+        self.state = bool(initial_value)
+        self._watchers = set()
+        self._button_handlers = []
+        self._ack = 0
+        self._callbacks = []
+
+        # Make pin discoverable like other config objects
+        self.printer.add_object(CHIP_NAME + ' ' + self.name, self)
+        self.printer.register_event_handler('klippy:ready', self._run_callbacks)
+        chip = _ensure_chip(self.printer)
+        chip.register_pin(self)
+
+    # pins framework -----------------------------------------------------
+    def setup_pin(self, pin_type, pin_params):
+        return VirtualEndstop(self, pin_params['invert'])
+
+    # watcher helpers ----------------------------------------------------
+    def register_watcher(self, cb):
+        """Register a callback for pin changes.
+
+        Callbacks may accept ``(eventtime, state)``, ``(state)``, or just
+        ``(eventtime)``.  The signature is detected automatically and the
+        callback immediately invoked with the current state.
+        """
+        et = self.printer.get_reactor().monotonic()
+        for mode in (2, 1, 0):
+            try:
+                if mode == 2:
+                    cb(et, self.state)
+                elif mode == 1:
+                    cb(self.state)
+                else:
+                    cb(et)
+            except TypeError:
+                continue
+            except Exception:
+                logging.exception('Virtual pin callback error')
+                continue
+            else:
+                self._watchers.add((cb, mode))
+                return
+        logging.error('Virtual pin watcher with incompatible signature')
+
+    def set_value(self, val):
+        val = bool(val)
+        if self.state == val:
+            return
+        self.state = val
+        et = self.printer.get_reactor().monotonic()
+        for cb, mode in list(self._watchers):
+            try:
+                if mode == 2:
+                    cb(et, val)
+                elif mode == 1:
+                    cb(val)
+                else:
+                    cb(et)
+            except Exception:
+                logging.exception('Virtual pin callback error')
+        for handler, oid in list(self._button_handlers):
+            params = {'ack_count': self._ack & 0xFF,
+                      'state': bytes([int(val)]),
+                      '#receive_time': et}
+            if oid is not None:
+                params['oid'] = oid
+            self._ack += 1
+            try:
+                handler(params)
+            except Exception:
+                logging.exception('Virtual button handler error')
+
+    def get_status(self, eventtime):
+        return {'value': int(self.state)}
+
+    # minimal MCU style methods -----------------------------------------
+    def register_config_callback(self, cb):
+        self._callbacks.append(cb)
+
+    def _run_callbacks(self, eventtime=None):
+        for cb in self._callbacks:
+            try:
+                cb()
+            except Exception:
+                logging.exception('Virtual pin config callback error')
+        self._callbacks = []
+
+    def create_oid(self):
+        return _ensure_chip(self.printer).create_oid()
+
+    def add_config_cmd(self, *args, **kwargs):
+        pass
+
+    class _DummyCmd:
+        def send(self, params):
+            pass
+
+    def alloc_command_queue(self):
+        return None
+
+    def lookup_command(self, template, cq=None):
+        return self._DummyCmd()
+
+    def get_query_slot(self, oid):
+        return 0
+
+    def seconds_to_clock(self, time):
+        return 0
+
+    def register_response(self, handler, resp_name=None, oid=None):
+        if resp_name == 'buttons_state':
+            self._button_handlers.append((handler, oid))
+            params = {'ack_count': self._ack & 0xFF,
+                      'state': bytes([int(self.state)]),
+                      '#receive_time': self.printer.get_reactor().monotonic()}
+            if oid is not None:
+                params['oid'] = oid
+            self._ack += 1
+            try:
+                handler(params)
+            except Exception:
+                logging.exception('Virtual button handler error')
+
+
+class SimpleFilamentSensor:
+    """Minimal filament sensor bound to a virtual pin."""
+
+    def __init__(self, printer, name, vpin):
+        self.printer = printer
+        self.name = name
+        self.vpin = vpin
+        self.enabled = True
+        self.filament_present = bool(vpin.state)
+        self.gcode = printer.lookup_object('gcode')
+        self.vpin.register_watcher(self._pin_changed)
+        self.gcode.register_mux_command(
+            'QUERY_FILAMENT_SENSOR', 'SENSOR', name,
+            self.cmd_QUERY_FILAMENT_SENSOR,
+            desc='Query the status of the Filament Sensor')
+        self.gcode.register_mux_command(
+            'SET_FILAMENT_SENSOR', 'SENSOR', name,
+            self.cmd_SET_FILAMENT_SENSOR,
+            desc='Enable/disable the Filament Sensor')
+        printer.add_object('filament_switch_sensor ' + name, self)
+
+    def _pin_changed(self, eventtime, state):
+        self.filament_present = bool(state)
+
+    def get_status(self, eventtime):
+        return {
+            'filament_detected': bool(self.filament_present),
+            'enabled': bool(self.enabled)
+        }
+
+    def cmd_QUERY_FILAMENT_SENSOR(self, gcmd):
+        if self.filament_present:
+            msg = f'Filament Sensor {self.name}: filament detected'
+        else:
+            msg = f'Filament Sensor {self.name}: filament not detected'
+        gcmd.respond_info(msg)
+
+    def cmd_SET_FILAMENT_SENSOR(self, gcmd):
+        self.enabled = gcmd.get_int('ENABLE', 1)
+
+
+def load_config_prefix(config):
+    """Entry point for `[ams_pin]` sections."""
+    return VirtualInputPin(config)
+
+
+class AmsPins:
+    """Create a fixed set of 8 AMS pins."""
+
+    def __init__(self, config):
+        printer = config.get_printer()
+        self.pins = []
+        self.sensors = []
+        for i in range(1, 9):
+            name = f'pin{i}'
+            vpin = VirtualInputPin(printer=printer, name=name, initial_value=False)
+            self.pins.append(vpin)
+            sensor = SimpleFilamentSensor(printer, name, vpin)
+            self.sensors.append(sensor)
+
+
+def load_config(config):
+    """Handler for a bare `[ams_pins]` section."""
+    return AmsPins(config)

--- a/klippy/extras/ams_pins.py
+++ b/klippy/extras/ams_pins.py
@@ -1,0 +1,22 @@
+"""Compatibility wrapper for `[ams_pins]` sections."""
+
+__all__ = ["load_config", "load_config_prefix", "AmsPins"]
+
+# Import lazily inside the helper functions so this module can be loaded even
+# if ``ams_pin`` has not finished initializing.
+
+def load_config(config):
+    from . import ams_pin as _ams_pin
+    return _ams_pin.load_config(config)
+
+
+def load_config_prefix(config):
+    from . import ams_pin as _ams_pin
+    return _ams_pin.load_config(config)
+
+
+def AmsPins(*args, **kwargs):
+    from . import ams_pin as _ams_pin
+    return _ams_pin.AmsPins(*args, **kwargs)
+
+

--- a/klippy/extras/filament_switch_sensor.py
+++ b/klippy/extras/filament_switch_sensor.py
@@ -1,0 +1,202 @@
+# Generic Filament Sensor Module
+#
+# Copyright (C) 2019  Eric Callahan <arksine.code@gmail.com>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+
+import logging
+from .ams_pin import _norm, CHIP_NAME
+
+
+class RunoutHelper:
+    def __init__(self, config):
+        self.name = config.get_name().split()[-1]
+        self.printer = config.get_printer()
+        self.reactor = self.printer.get_reactor()
+        self.gcode = self.printer.lookup_object('gcode')
+        # Read config
+        self.runout_pause = config.getboolean('pause_on_runout', True)
+        if self.runout_pause:
+            self.printer.load_object(config, 'pause_resume')
+        self.runout_gcode = self.insert_gcode = None
+        gcode_macro = self.printer.load_object(config, 'gcode_macro')
+        if self.runout_pause or config.get('runout_gcode', None) is not None:
+            self.runout_gcode = gcode_macro.load_template(
+                config, 'runout_gcode', '')
+        if config.get('insert_gcode', None) is not None:
+            self.insert_gcode = gcode_macro.load_template(
+                config, 'insert_gcode')
+        self.pause_delay = config.getfloat('pause_delay', .5, above=.0)
+        self.event_delay = config.getfloat('event_delay', 3., minval=.0)
+        # Internal state
+        self.min_event_systime = self.reactor.NEVER
+        self.filament_present = False
+        self.sensor_enabled = True
+        # Register commands and event handlers
+        self.printer.register_event_handler('klippy:ready', self._handle_ready)
+        self.gcode.register_mux_command(
+            'QUERY_FILAMENT_SENSOR', 'SENSOR', self.name,
+            self.cmd_QUERY_FILAMENT_SENSOR,
+            desc=self.cmd_QUERY_FILAMENT_SENSOR_help)
+        self.gcode.register_mux_command(
+            'SET_FILAMENT_SENSOR', 'SENSOR', self.name,
+            self.cmd_SET_FILAMENT_SENSOR,
+            desc=self.cmd_SET_FILAMENT_SENSOR_help)
+
+    def _handle_ready(self):
+        self.min_event_systime = self.reactor.monotonic() + 2.
+
+    def _runout_event_handler(self, eventtime):
+        # Pausing from inside an event requires that the pause portion
+        # of pause_resume execute immediately.
+        pause_prefix = ''
+        if self.runout_pause:
+            pause_resume = self.printer.lookup_object('pause_resume')
+            pause_resume.send_pause_command()
+            pause_prefix = 'PAUSE\n'
+            self.printer.get_reactor().pause(eventtime + self.pause_delay)
+        self._exec_gcode(pause_prefix, self.runout_gcode)
+
+    def _insert_event_handler(self, eventtime):
+        self._exec_gcode('', self.insert_gcode)
+
+    def _exec_gcode(self, prefix, template):
+        try:
+            self.gcode.run_script(prefix + template.render() + '\nM400')
+        except Exception:
+            logging.exception('Script running error')
+        self.min_event_systime = self.reactor.monotonic() + self.event_delay
+
+    def note_filament_present(self, eventtime, is_filament_present):
+        if is_filament_present == self.filament_present:
+            return
+        self.filament_present = is_filament_present
+
+        if eventtime < self.min_event_systime or not self.sensor_enabled:
+            # do not process during the initialization time, duplicates,
+            # during the event delay time, while an event is running, or
+            # when the sensor is disabled
+            return
+
+        # Determine "printing" status
+        now = self.reactor.monotonic()
+        idle_timeout = self.printer.lookup_object('idle_timeout')
+        is_printing = idle_timeout.get_status(now)['state'] == 'Printing'
+
+        # Perform filament action associated with status change (if any)
+        if is_filament_present:
+            if not is_printing and self.insert_gcode is not None:
+                # insert detected
+                self.min_event_systime = self.reactor.NEVER
+                logging.info(
+                    'Filament Sensor %s: insert event detected, Time %.2f' %
+                    (self.name, now))
+                self.reactor.register_callback(self._insert_event_handler)
+        elif is_printing and self.runout_gcode is not None:
+            # runout detected
+            self.min_event_systime = self.reactor.NEVER
+            logging.info(
+                'Filament Sensor %s: runout event detected, Time %.2f' %
+                (self.name, now))
+            self.reactor.register_callback(self._runout_event_handler)
+
+    def get_status(self, eventtime):
+        return {
+            'filament_detected': bool(self.filament_present),
+            'enabled': bool(self.sensor_enabled)
+        }
+
+    cmd_QUERY_FILAMENT_SENSOR_help = 'Query the status of the Filament Sensor'
+    def cmd_QUERY_FILAMENT_SENSOR(self, gcmd):
+        if self.filament_present:
+            msg = 'Filament Sensor %s: filament detected' % (self.name)
+        else:
+            msg = 'Filament Sensor %s: filament not detected' % (self.name)
+        gcmd.respond_info(msg)
+
+    cmd_SET_FILAMENT_SENSOR_help = 'Sets the filament sensor on/off'
+    def cmd_SET_FILAMENT_SENSOR(self, gcmd):
+        self.sensor_enabled = gcmd.get_int('ENABLE', 1)
+
+
+class SwitchSensor:
+    def __init__(self, config):
+        printer = config.get_printer()
+        buttons = printer.load_object(config, 'buttons')
+        switch_pin = config.get('switch_pin')
+        buttons.register_debounce_button(switch_pin, self._button_handler,
+                                         config)
+        self.runout_helper = RunoutHelper(config)
+        self.get_status = self.runout_helper.get_status
+
+    def _button_handler(self, eventtime, state):
+        self.runout_helper.note_filament_present(eventtime, state)
+
+
+class VirtualSwitchSensor:
+    """Emulated filament sensor triggered by a virtual pin."""
+    def __init__(self, config, vpin_name):
+        self.printer = config.get_printer()
+        self.vpin_name = _norm(vpin_name)
+        self.vpin = None
+        self.reactor = self.printer.get_reactor()
+        self.runout_helper = RunoutHelper(config)
+        # Defer binding until Klipper is ready so virtual pin sections can
+        # appear anywhere in the config file
+        self.printer.register_event_handler('klippy:ready', self._bind_pin)
+        self.get_status = self.runout_helper.get_status
+
+    def _bind_pin(self, eventtime=None):
+        if self.vpin is not None:
+            return
+        vpin = self.printer.lookup_object(CHIP_NAME + ' ' + self.vpin_name, None)
+        if vpin is None:
+            logging.error('virtual pin %s not configured', self.vpin_name)
+            return
+        self.vpin = vpin
+        self.vpin.register_watcher(self._pin_changed)
+        self.runout_helper.note_filament_present(self.reactor.monotonic(),
+                                                 bool(self.vpin.state))
+
+    def _pin_changed(self, eventtime, val):
+        self.runout_helper.note_filament_present(eventtime, bool(val))
+
+
+def load_config_prefix(config):
+    printer = config.get_printer()
+    switch_pin = config.get('switch_pin')
+    ppins = printer.lookup_object('pins')
+
+    # Try normal pin parsing first in case the virtual pin chip
+    # has already been registered
+    try:
+        pin_params = ppins.parse_pin(switch_pin, can_invert=True, can_pullup=True)
+        if pin_params['chip_name'] == CHIP_NAME:
+            vpin_name = _norm(pin_params['pin'])
+            vpin = printer.lookup_object(CHIP_NAME + ' ' + vpin_name, None)
+            if vpin is None:
+                # Delay binding until klippy:ready if pin not loaded yet
+                return VirtualSwitchSensor(config, vpin_name)
+            return VirtualSwitchSensor(config, vpin_name)
+        return SwitchSensor(config)
+    except Exception:
+    # Fall back to detecting f"{CHIP_NAME}:" prefix without requiring
+        # the chip to be registered yet
+        pass
+
+    # Basic manual parsing for strings like f"!{CHIP_NAME}:name" or
+    # f"^!{CHIP_NAME}:name".  Pullup and invert modifiers are ignored
+    # since virtual pins do not use them.
+    clean_pin = switch_pin.lstrip('!^')
+    prefix = CHIP_NAME + ':'
+    if clean_pin.startswith(prefix):
+        vpin_name = _norm(clean_pin.split(prefix, 1)[1])
+        vpin = printer.lookup_object(CHIP_NAME + ' ' + vpin_name, None)
+        if vpin is None:
+            # Delay binding until klippy:ready if pin not loaded yet
+            return VirtualSwitchSensor(config, vpin_name)
+        return VirtualSwitchSensor(config, vpin_name)
+
+    # If all checks fail, fall back to the normal hardware switch sensor
+    return SwitchSensor(config)
+

--- a/klippy/extras/virtual_filament_sensor.py
+++ b/klippy/extras/virtual_filament_sensor.py
@@ -1,0 +1,16 @@
+# Wrapper module providing [virtual_filament_sensor] via virtual pins
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+
+from .filament_switch_sensor import VirtualSwitchSensor
+from .ams_pin import CHIP_NAME
+
+
+def load_config_prefix(config):
+    """Config handler for [virtual_filament_sensor] sections."""
+    pin = config.get('pin')
+    if pin.startswith(CHIP_NAME + ':'):
+        vpin_name = pin.split(CHIP_NAME + ':', 1)[1].strip()
+    else:
+        vpin_name = pin.strip()
+    return VirtualSwitchSensor(config, vpin_name)


### PR DESCRIPTION
## Summary
- use `ams` as the virtual chip name
- allow `VirtualInputPin` to be created programmatically
- add `[ams_pins]` section which creates eight pins named `pin1`..`pin8`
- tie a simple filament sensor to each pin so the system can read their status
- add wrapper module so `[ams_pins]` loads correctly
- export `_norm` and `CHIP_NAME` so helper modules can import them

## Testing
- `python -m py_compile klippy/extras/ams_pin.py klippy/extras/ams_pins.py klippy/extras/filament_switch_sensor.py klippy/extras/virtual_filament_sensor.py`


------
https://chatgpt.com/codex/tasks/task_e_687d26d022048326b90b8e61ea8b8d1b