### PR TITLE
Add ams chip alias for virtual pins

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,25 @@
-# Klipper-Backup 💾 
-Klipper backup script for manual or automated GitHub backups 
+# Klipper-Backup 💾
+Klipper backup script for manual or automated GitHub backups
 
 This backup is provided by [Klipper-Backup](https://github.com/Staubgeborener/klipper-backup).
+
+## Virtual input pins
+
+This repository includes a small Klipper module that lets you define
+software input pins.  Pins register under the chip name `virtual_pin` but
+aliases of `ams_pin` and `ams` are also provided.  Thus a pin can be
+referenced as `virtual_pin:name`, `ams_pin:name`, or simply `ams:name`
+in other configuration sections.
+
+Legacy configurations using `[ams_pin]` sections continue to work via a
+compatibility wrapper that forwards to the same implementation.
+
+Add a section such as:
+
+```
+[virtual_input_pin runout_button]
+initial_value: 1
+```
+
+Change the pin state with `SET_VIRTUAL_PIN PIN=runout_button VALUE=0`
+and query it with `QUERY_VIRTUAL_PIN PIN=runout_button`.

--- a/klippy/extras/__init__.py
+++ b/klippy/extras/__init__.py
@@ -1,0 +1,1 @@
+# Package for extra modules

--- a/klippy/extras/ams_pin.py
+++ b/klippy/extras/ams_pin.py
@@ -1,0 +1,23 @@
+"""Compatibility wrapper for deprecated ams_pin module.
+
+This module preserves the old :mod:`ams_pin` name while reusing the
+``virtual_input_pin`` implementation.  Config sections such as
+``[ams_pin my_pin]`` will continue to work by forwarding to
+``virtual_input_pin``.
+"""
+
+from .virtual_input_pin import VirtualInputPin, load_config_prefix
+
+CHIP_NAME = 'virtual_pin'
+
+
+def _norm(name: str) -> str:
+    """Normalize a pin name."""
+    return name.strip().lower()
+
+__all__ = [
+    'VirtualInputPin',
+    'load_config_prefix',
+    '_norm',
+    'CHIP_NAME',
+]

--- a/klippy/extras/virtual_input_pin.py
+++ b/klippy/extras/virtual_input_pin.py
@@ -1,0 +1,110 @@
+"""Software-defined input pins for Klipper.
+
+This module allows configuration sections like `[virtual_input_pin foo]`
+to create pins that behave like MCU endstop inputs.  Each pin can be
+queried or updated at runtime using the `SET_VIRTUAL_PIN` and
+`QUERY_VIRTUAL_PIN` gcode commands.
+"""
+
+import logging
+
+
+class VirtualEndstop:
+    """Minimal endstop object wrapping a virtual pin."""
+
+    def __init__(self, vpin, invert):
+        self._vpin = vpin
+        self._invert = invert
+        self._reactor = vpin.printer.get_reactor()
+
+    def get_mcu(self):
+        return None
+
+    def add_stepper(self, stepper):
+        pass
+
+    def get_steppers(self):
+        return []
+
+    def home_start(self, print_time, *args, **kwargs):
+        comp = self._reactor.completion()
+        comp.complete(self.query_endstop(print_time))
+        return comp
+
+    def home_wait(self, home_end_time):
+        if self.query_endstop(home_end_time):
+            return home_end_time
+        return 0.
+
+    def query_endstop(self, print_time):
+        return bool(self._vpin.state) ^ bool(self._invert)
+
+
+class VirtualInputPin:
+    """Representation of a virtual input pin."""
+
+    def __init__(self, config):
+        self.printer = config.get_printer()
+        self.name = config.get_name().split()[-1]
+        self.state = config.getboolean('initial_value', False)
+        self._watchers = []
+
+        ppins = self.printer.lookup_object('pins')
+        for cname in ('virtual_pin', 'ams_pin', 'ams'):
+            try:
+                ppins.register_chip(cname, self)
+            except ppins.error:
+                pass
+
+        gcode = self.printer.lookup_object('gcode')
+        cname = self.name
+        gcode.register_mux_command('SET_VIRTUAL_PIN', 'PIN', cname,
+                                   self._cmd_set,
+                                   desc=self._cmd_set_help)
+        gcode.register_mux_command('QUERY_VIRTUAL_PIN', 'PIN', cname,
+                                   self._cmd_query,
+                                   desc=self._cmd_query_help)
+
+    def setup_pin(self, pin_type, pin_params):
+        ppins = self.printer.lookup_object('pins')
+        if pin_type != 'endstop':
+            raise ppins.error('virtual_pin only supports endstop type')
+        return VirtualEndstop(self, pin_params['invert'])
+
+    # watcher helpers -------------------------------------------------
+    def register_watcher(self, cb):
+        self._watchers.append(cb)
+        try:
+            cb(self.printer.get_reactor().monotonic(), self.state)
+        except Exception:
+            logging.exception('virtual pin callback error')
+
+    def set_value(self, val):
+        val = bool(val)
+        if self.state == val:
+            return
+        self.state = val
+        et = self.printer.get_reactor().monotonic()
+        for cb in list(self._watchers):
+            try:
+                cb(et, val)
+            except Exception:
+                logging.exception('virtual pin callback error')
+
+    # gcode commands --------------------------------------------------
+    _cmd_set_help = 'Set the value of a virtual input pin'
+
+    def _cmd_set(self, gcmd):
+        val = gcmd.get_int('VALUE', 1)
+        self.set_value(val)
+
+    _cmd_query_help = 'Report the value of a virtual input pin'
+
+    def _cmd_query(self, gcmd):
+        gcmd.respond_info('virtual_pin %s: %d' % (self.name, self.state))
+
+
+# Configuration entry point
+
+def load_config_prefix(config):
+    return VirtualInputPin(config)


### PR DESCRIPTION
## Summary
- document that pins register under `virtual_pin`, `ams_pin`, or `ams`
- register all three chip names when creating a virtual pin

## Testing
- `python -m py_compile klippy/extras/virtual_input_pin.py klippy/extras/ams_pin.py`


------
https://chatgpt.com/codex/tasks/task_e_687d26d022048326b90b8e61ea8b8d1b