### PR TITLE
Improve virtual pin registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,34 @@
-# Klipper-Backup 💾 
-Klipper backup script for manual or automated GitHub backups 
+# Klipper-Backup 💾
+Klipper backup script for manual or automated GitHub backups
 
 This backup is provided by [Klipper-Backup](https://github.com/Staubgeborener/klipper-backup).
+
+## AMS virtual pins
+
+This repository includes a small Klipper module that creates eight
+software input pins on a fake MCU named `ams`.  After adding the section
+
+```
+[ams_virtual_pins]
+```
+
+to your configuration, pins `pin1` through `pin8` become available under
+the chip name `ams` (or the alias `virtual_pin`).  They may be referenced
+like normal endstop pins,
+for example:
+
+```
+[filament_switch_sensor my_sensor]
+    switch_pin: ams:pin1
+```
+
+Change a pin state at runtime with:
+
+```
+SET_AMS_PIN PIN=pin1 VALUE=1
+QUERY_AMS_PIN PIN=pin1
+# The `PIN` parameter may use either `pin1` or `virtual_pin:pin1`.
+```
+
+These pins behave like real endstop inputs, so they can be used anywhere
+an input pin is expected.

--- a/klippy/extras/__init__.py
+++ b/klippy/extras/__init__.py
@@ -1,0 +1,1 @@
+# Package for extra modules

--- a/klippy/extras/ams_virtual_pins.py
+++ b/klippy/extras/ams_virtual_pins.py
@@ -1,0 +1,232 @@
+# Software-defined AMS pins for Klipper
+#
+# Creates eight virtual input pins named pin1-pin8 on a fake MCU named 'ams'.
+# Pins act like endstop inputs and can be referenced elsewhere in the
+# configuration using `ams:pin1`, `ams:pin2`, etc.  Their state can be
+# changed at runtime with SET_AMS_PIN and queried with QUERY_AMS_PIN.
+#
+# Copyright (C) 2024
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+
+import logging
+
+CHIP_NAME = "ams"
+# Allow either "ams" or "virtual_pin" as the chip name so existing
+# configurations using the virtual_pin prefix continue to work.
+CHIP_ALIASES = (CHIP_NAME, "virtual_pin")
+
+def _norm(name: str) -> str:
+    """Normalize a pin name for lookups."""
+    return str(name).strip().lower()
+
+class VirtualEndstop:
+    def __init__(self, vpin, invert):
+        self._vpin = vpin
+        self._invert = invert
+        self._reactor = vpin.chip.printer.get_reactor()
+
+    def get_mcu(self):
+        return None
+
+    def add_stepper(self, stepper):
+        pass
+
+    def get_steppers(self):
+        return []
+
+    def home_start(self, print_time, *args, **kwargs):
+        c = self._reactor.completion()
+        c.complete(self.query_endstop(print_time))
+        return c
+
+    def home_wait(self, home_end_time):
+        if self.query_endstop(home_end_time):
+            return home_end_time
+        return 0.
+
+    def query_endstop(self, print_time):
+        return bool(self._vpin.state) ^ bool(self._invert)
+
+class VirtualInputPin:
+    def __init__(self, chip, name):
+        self.chip = chip
+        self.name = name
+        self.state = False
+        self._watchers = set()
+
+    # MCU helpers forwarded from chip
+    def register_config_callback(self, cb):
+        self.chip.register_config_callback(cb)
+    def register_response(self, cb, *args):
+        self.chip.register_response(cb, *args)
+    def add_config_cmd(self, cmd, is_init=False):
+        self.chip.add_config_cmd(cmd, is_init)
+    def alloc_command_queue(self):
+        return self.chip.alloc_command_queue()
+    def lookup_command(self, *args, **kw):
+        return self.chip.lookup_command(*args, **kw)
+    def get_query_slot(self, oid):
+        return self.chip.get_query_slot(oid)
+    def seconds_to_clock(self, seconds):
+        return self.chip.seconds_to_clock(seconds)
+    def create_oid(self):
+        return self.chip.create_oid()
+
+    def setup_pin(self, pin_type, pin_params):
+        ppins = self.chip.printer.lookup_object('pins')
+        if pin_type != 'endstop':
+            raise ppins.error('ams pins only support endstop type')
+        invert = pin_params.get('invert', False)
+        return VirtualEndstop(self, invert)
+
+    def register_watcher(self, cb):
+        if cb not in self._watchers:
+            self._watchers.add(cb)
+            self._invoke(cb, self.state)
+
+    def _invoke(self, cb, state):
+        et = self.chip.printer.get_reactor().monotonic()
+        try:
+            cb(et, state)
+            return
+        except TypeError:
+            pass
+        try:
+            cb(state)
+            return
+        except TypeError:
+            pass
+        try:
+            cb(et)
+        except Exception:
+            logging.exception('Virtual pin callback error')
+
+    def set_value(self, val):
+        val = bool(val)
+        if self.state == val:
+            return
+        self.state = val
+        for cb in list(self._watchers):
+            self._invoke(cb, val)
+
+    def get_status(self, eventtime):
+        return { 'value': int(self.state) }
+
+class VirtualPinChip:
+    def __init__(self, printer):
+        self.printer = printer
+        self.pins = {}
+        self._config_cbs = []
+        self._oid = 0
+
+    # MCU interface stubs
+    def register_config_callback(self, cb):
+        self._config_cbs.append(cb)
+    def run_config_callbacks(self, eventtime=None):
+        cbs = self._config_cbs
+        self._config_cbs = []
+        for cb in cbs:
+            try:
+                if eventtime is None:
+                    cb()
+                else:
+                    cb(eventtime)
+            except TypeError:
+                cb()
+    def register_response(self, cb, *args):
+        pass
+    def add_config_cmd(self, cmd, is_init=False):
+        pass
+    def alloc_command_queue(self):
+        class Dummy: 
+            def send(self,*a,**k):
+                pass
+        return Dummy()
+    class _DummyCmd:
+        def send(self,*a,**k):
+            pass
+    def lookup_command(self,*a,**k):
+        return self._DummyCmd()
+    def get_query_slot(self, oid):
+        return 0
+    def seconds_to_clock(self, seconds):
+        return 0
+    def create_oid(self):
+        self._oid += 1
+        return self._oid
+
+    def setup_pin(self, pin_type, pin_params):
+        name = _norm(pin_params['pin'])
+        vp = self.pins.get(name)
+        if vp is None:
+            ppins = self.printer.lookup_object('pins')
+            raise ppins.error('ams pin %s not configured' % name)
+        return vp.setup_pin(pin_type, pin_params)
+
+# G-code handlers -------------------------------------------------------
+
+    def _parse_pin_arg(self, gcmd):
+        name = _norm(gcmd.get('PIN'))
+        for prefix in (alias + ':' for alias in CHIP_ALIASES):
+            if name.startswith(prefix):
+                name = name[len(prefix):]
+                break
+        return name
+
+    def cmd_SET_AMS_PIN(self, gcmd):
+        name = self._parse_pin_arg(gcmd)
+        val = gcmd.get_int('VALUE', 1)
+        pin = self.pins.get(name)
+        if pin is None:
+            gcmd.respond_info('Unknown ams pin %s' % name)
+            return
+        pin.set_value(val)
+
+    def cmd_QUERY_AMS_PIN(self, gcmd):
+        name = self._parse_pin_arg(gcmd)
+        pin = self.pins.get(name)
+        if pin is None:
+            gcmd.respond_info('Unknown ams pin %s' % name)
+            return
+        gcmd.respond_info('ams:%s=%d' % (name, pin.state))
+
+# Configuration entry point --------------------------------------------
+
+def load_config(config):
+    printer = config.get_printer()
+    chip = VirtualPinChip(printer)
+    ppins = printer.lookup_object('pins')
+    for name in CHIP_ALIASES:
+        try:
+            ppins.register_chip(name, chip)
+        except ppins.error:
+            pass
+    # create eight pins pin1..pin8
+    for i in range(1,9):
+        name = f'pin{i}'
+        vp = VirtualInputPin(chip, name)
+        chip.pins[_norm(name)] = vp
+        # expose for macros via printer.objects
+        objs = getattr(printer, 'objects', None)
+        if isinstance(objs, dict):
+            # expose under canonical chip name and the alias so lookups
+            # from other modules succeed regardless of which prefix was
+            # used
+            objs[f'{CHIP_NAME} {name}'] = vp
+            objs[f'ams_pin {name}'] = vp
+    # register gcode commands
+    gcode = printer.lookup_object('gcode')
+    gcode.register_command('SET_AMS_PIN', chip.cmd_SET_AMS_PIN,
+                           desc='Set ams pin value')
+    gcode.register_command('QUERY_AMS_PIN', chip.cmd_QUERY_AMS_PIN,
+                           desc='Query ams pin value')
+    printer.register_event_handler('klippy:connect', chip.run_config_callbacks)
+    printer.ams = chip
+    return chip
+
+# allow [ams_virtual_pins] with optional suffix
+
+def load_config_prefix(config):
+    return load_config(config)
+

--- a/klippy/extras/filament_switch_sensor.py
+++ b/klippy/extras/filament_switch_sensor.py
@@ -1,0 +1,203 @@
+# Generic Filament Sensor Module
+#
+# Copyright (C) 2019  Eric Callahan <arksine.code@gmail.com>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+
+import logging
+from .ams_virtual_pins import _norm, CHIP_NAME, CHIP_ALIASES
+
+
+class RunoutHelper:
+    def __init__(self, config):
+        self.name = config.get_name().split()[-1]
+        self.printer = config.get_printer()
+        self.reactor = self.printer.get_reactor()
+        self.gcode = self.printer.lookup_object('gcode')
+        # Read config
+        self.runout_pause = config.getboolean('pause_on_runout', True)
+        if self.runout_pause:
+            self.printer.load_object(config, 'pause_resume')
+        self.runout_gcode = self.insert_gcode = None
+        gcode_macro = self.printer.load_object(config, 'gcode_macro')
+        if self.runout_pause or config.get('runout_gcode', None) is not None:
+            self.runout_gcode = gcode_macro.load_template(
+                config, 'runout_gcode', '')
+        if config.get('insert_gcode', None) is not None:
+            self.insert_gcode = gcode_macro.load_template(
+                config, 'insert_gcode')
+        self.pause_delay = config.getfloat('pause_delay', .5, above=.0)
+        self.event_delay = config.getfloat('event_delay', 3., minval=.0)
+        # Internal state
+        self.min_event_systime = self.reactor.NEVER
+        self.filament_present = False
+        self.sensor_enabled = True
+        # Register commands and event handlers
+        self.printer.register_event_handler('klippy:ready', self._handle_ready)
+        self.gcode.register_mux_command(
+            'QUERY_FILAMENT_SENSOR', 'SENSOR', self.name,
+            self.cmd_QUERY_FILAMENT_SENSOR,
+            desc=self.cmd_QUERY_FILAMENT_SENSOR_help)
+        self.gcode.register_mux_command(
+            'SET_FILAMENT_SENSOR', 'SENSOR', self.name,
+            self.cmd_SET_FILAMENT_SENSOR,
+            desc=self.cmd_SET_FILAMENT_SENSOR_help)
+
+    def _handle_ready(self):
+        self.min_event_systime = self.reactor.monotonic() + 2.
+
+    def _runout_event_handler(self, eventtime):
+        # Pausing from inside an event requires that the pause portion
+        # of pause_resume execute immediately.
+        pause_prefix = ''
+        if self.runout_pause:
+            pause_resume = self.printer.lookup_object('pause_resume')
+            pause_resume.send_pause_command()
+            pause_prefix = 'PAUSE\n'
+            self.printer.get_reactor().pause(eventtime + self.pause_delay)
+        self._exec_gcode(pause_prefix, self.runout_gcode)
+
+    def _insert_event_handler(self, eventtime):
+        self._exec_gcode('', self.insert_gcode)
+
+    def _exec_gcode(self, prefix, template):
+        try:
+            self.gcode.run_script(prefix + template.render() + '\nM400')
+        except Exception:
+            logging.exception('Script running error')
+        self.min_event_systime = self.reactor.monotonic() + self.event_delay
+
+    def note_filament_present(self, eventtime, is_filament_present):
+        if is_filament_present == self.filament_present:
+            return
+        self.filament_present = is_filament_present
+
+        if eventtime < self.min_event_systime or not self.sensor_enabled:
+            # do not process during the initialization time, duplicates,
+            # during the event delay time, while an event is running, or
+            # when the sensor is disabled
+            return
+
+        # Determine "printing" status
+        now = self.reactor.monotonic()
+        idle_timeout = self.printer.lookup_object('idle_timeout')
+        is_printing = idle_timeout.get_status(now)['state'] == 'Printing'
+
+        # Perform filament action associated with status change (if any)
+        if is_filament_present:
+            if not is_printing and self.insert_gcode is not None:
+                # insert detected
+                self.min_event_systime = self.reactor.NEVER
+                logging.info(
+                    'Filament Sensor %s: insert event detected, Time %.2f' %
+                    (self.name, now))
+                self.reactor.register_callback(self._insert_event_handler)
+        elif is_printing and self.runout_gcode is not None:
+            # runout detected
+            self.min_event_systime = self.reactor.NEVER
+            logging.info(
+                'Filament Sensor %s: runout event detected, Time %.2f' %
+                (self.name, now))
+            self.reactor.register_callback(self._runout_event_handler)
+
+    def get_status(self, eventtime):
+        return {
+            'filament_detected': bool(self.filament_present),
+            'enabled': bool(self.sensor_enabled)
+        }
+
+    cmd_QUERY_FILAMENT_SENSOR_help = 'Query the status of the Filament Sensor'
+    def cmd_QUERY_FILAMENT_SENSOR(self, gcmd):
+        if self.filament_present:
+            msg = 'Filament Sensor %s: filament detected' % (self.name)
+        else:
+            msg = 'Filament Sensor %s: filament not detected' % (self.name)
+        gcmd.respond_info(msg)
+
+    cmd_SET_FILAMENT_SENSOR_help = 'Sets the filament sensor on/off'
+    def cmd_SET_FILAMENT_SENSOR(self, gcmd):
+        self.sensor_enabled = gcmd.get_int('ENABLE', 1)
+
+
+class SwitchSensor:
+    def __init__(self, config):
+        printer = config.get_printer()
+        buttons = printer.load_object(config, 'buttons')
+        switch_pin = config.get('switch_pin')
+        buttons.register_debounce_button(switch_pin, self._button_handler,
+                                         config)
+        self.runout_helper = RunoutHelper(config)
+        self.get_status = self.runout_helper.get_status
+
+    def _button_handler(self, eventtime, state):
+        self.runout_helper.note_filament_present(eventtime, state)
+
+
+class VirtualSwitchSensor:
+    """Emulated filament sensor triggered by a virtual pin."""
+    def __init__(self, config, vpin_name):
+        self.printer = config.get_printer()
+        self.vpin_name = _norm(vpin_name)
+        self.vpin = None
+        self.reactor = self.printer.get_reactor()
+        self.runout_helper = RunoutHelper(config)
+        # Defer binding until Klipper is ready so virtual pin sections can
+        # appear anywhere in the config file
+        self.printer.register_event_handler('klippy:ready', self._bind_pin)
+        self.get_status = self.runout_helper.get_status
+
+    def _bind_pin(self, eventtime=None):
+        if self.vpin is not None:
+            return
+        vpin = self.printer.lookup_object(CHIP_NAME + ' ' + self.vpin_name, None)
+        if vpin is None:
+            logging.error('virtual pin %s not configured', self.vpin_name)
+            return
+        self.vpin = vpin
+        self.vpin.register_watcher(self._pin_changed)
+        self.runout_helper.note_filament_present(self.reactor.monotonic(),
+                                                 bool(self.vpin.state))
+
+    def _pin_changed(self, eventtime, val):
+        self.runout_helper.note_filament_present(eventtime, bool(val))
+
+
+def load_config_prefix(config):
+    printer = config.get_printer()
+    switch_pin = config.get('switch_pin')
+    ppins = printer.lookup_object('pins')
+
+    # Try normal pin parsing first in case the virtual pin chip
+    # has already been registered
+    try:
+        pin_params = ppins.parse_pin(switch_pin, can_invert=True, can_pullup=True)
+        if pin_params['chip_name'] in CHIP_ALIASES:
+            vpin_name = _norm(pin_params['pin'])
+            # Look up using canonical chip name
+            vpin = printer.lookup_object(CHIP_NAME + ' ' + vpin_name, None)
+            if vpin is None:
+                # Delay binding until klippy:ready if pin not loaded yet
+                return VirtualSwitchSensor(config, vpin_name)
+            return VirtualSwitchSensor(config, vpin_name)
+        return SwitchSensor(config)
+    except Exception:
+    # Fall back to detecting f"{CHIP_NAME}:" prefix without requiring
+        # the chip to be registered yet
+        pass
+
+    # Basic manual parsing for strings like f"!{CHIP_NAME}:name" or
+    # f"^!{CHIP_NAME}:name".  Pullup and invert modifiers are ignored
+    # since virtual pins do not use them.
+    clean_pin = switch_pin.lstrip('!^')
+    for prefix in (alias + ':' for alias in CHIP_ALIASES):
+        if clean_pin.startswith(prefix):
+            vpin_name = _norm(clean_pin.split(prefix, 1)[1])
+            vpin = printer.lookup_object(CHIP_NAME + ' ' + vpin_name, None)
+            if vpin is None:
+                # Delay binding until klippy:ready if pin not loaded yet
+                return VirtualSwitchSensor(config, vpin_name)
+            return VirtualSwitchSensor(config, vpin_name)
+
+    # If all checks fail, fall back to the normal hardware switch sensor
+    return SwitchSensor(config)
+


### PR DESCRIPTION
## Summary
- register ams pins under `ams pinN` as well as `ams_pin pinN`
- expose them for easier lookup by other modules

## Testing
- `python3 -m py_compile klippy/extras/ams_virtual_pins.py klippy/extras/filament_switch_sensor.py`

------
https://chatgpt.com/codex/tasks/task_e_687d26d022048326b90b8e61ea8b8d1b