### PR TITLE
Update AMS virtual pin docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,33 +4,37 @@ This backup is provided by [Klipper-Backup](https://github.com/Staubgeborener/kl
 
 ## AMS virtual pins
 
-This repository includes a small Klipper module that creates eight
-software input pins on a fake MCU named `ams`.  After adding the section
+Use Klipper's `virtual_input_pin` module with `auto_ams_update` to
+mirror AMS lane status. `auto_ams_update` will automatically create
+virtual pins for the names listed in its `pins` option:
 
 ```
-[ams_virtual_pins]
+[auto_ams_update]
+oams1: oams1
+oams2: oams2
+pins: ams1lane0pl, ams1lane1pl, ams1lane2pl, ams1lane3pl, \
+      ams2lane0pl, ams2lane1pl, ams2lane2pl, ams2lane3pl, \
+      ams1hub0, ams1hub1, ams1hub2, ams1hub3, \
+      ams2hub0, ams2hub1, ams2hub2, ams2hub3
+interval: 1
 ```
 
-to your configuration, pins `pin1` through `pin8` become available under
-the chip name `ams` (or the aliases `ams_pin` and `virtual_pin`).  They may be referenced
-like normal endstop pins,
-for example:
+Add more `oams#` options (for example, `oams3: oams3`) and extend the
+`pins` list with that AMS's pin names. List the lane pins for all AMS
+units first, followed by the hub pins for all AMS units. Additional
+virtual pins may still be defined manually using `[virtual_input_pin
+my_pin]` if needed.
+
+Use these pins like normal endstop pins:
 
 ```
 [filament_switch_sensor my_sensor]
-    switch_pin: ams:pin1
+    switch_pin: virtual_pin:ams1lane0pl
 ```
 
-Change a pin state at runtime with:
-
-```
-SET_AMS_PIN PIN=pin1 VALUE=1
-QUERY_AMS_PIN PIN=pin1
-# The `PIN` parameter may use either `pin1`, `ams_pin:pin1`, or `virtual_pin:pin1`.
-```
-
-These pins behave like real endstop inputs, so they can be used anywhere
-an input pin is expected.
+Change a pin state at runtime with `SET_VIRTUAL_PIN` and query it with
+`QUERY_VIRTUAL_PIN`. These pins behave like real endstop inputs, so they
+can be used anywhere an input pin is expected.
 
 ## Virtual input pins
 

--- a/klipper/klippy/extras/auto_ams_update.py
+++ b/klipper/klippy/extras/auto_ams_update.py
@@ -1,6 +1,30 @@
 import logging
+from . import virtual_input_pin
 
 SYNC_INTERVAL = 2.0
+
+
+class _VPinConfig:
+    """Minimal config wrapper used to create virtual_input_pin objects."""
+
+    def __init__(self, printer, name):
+        self._printer = printer
+        self._name = f'virtual_input_pin {name}'
+
+    def get_printer(self):
+        return self._printer
+
+    def get_name(self):
+        return self._name
+
+    def getboolean(self, key, default=False):
+        return default
+
+    def get(self, key, default=None):
+        return default
+
+    def error(self, msg):
+        raise Exception(msg)
 
 class AutoAMSUpdate:
     """Periodically update virtual pins from AMS lane status."""
@@ -10,16 +34,32 @@ class AutoAMSUpdate:
         self.reactor = self.printer.get_reactor()
         self.gcode = self.printer.lookup_object('gcode')
         self.interval = config.getfloat('interval', SYNC_INTERVAL, above=0.)
-        self.oams1_name = config.get('oams1', 'oams1').strip()
-        self.oams2_name = config.get('oams2', 'oams2').strip()
-        self.pin_names = config.getlist(
-            'pins',
-            (
-                'pin1','pin2','pin3','pin4','pin5','pin6','pin7','pin8',
-                'pin9','pin10','pin11','pin12','pin13','pin14','pin15','pin16',
-            ))
-        if len(self.pin_names) != 16:
-            raise config.error('pins option must contain sixteen pin names')
+        # Find all oams#: options and sort by numeric suffix
+        oams_opts = config.get_prefix_options('oams')
+        if oams_opts:
+            def sort_key(opt):
+                suffix = opt[4:]
+                return int(suffix) if suffix.isdigit() else opt
+            oams_opts = sorted(oams_opts, key=sort_key)
+            self.oams_names = [config.get(opt).strip() for opt in oams_opts]
+        else:
+            # Default to two AMS objects for backwards compatibility
+            self.oams_names = ['oams1', 'oams2']
+        # Expect eight pins (4 lane + 4 hub) per AMS unit
+        default_pins = [f'pin{i+1}' for i in range(8 * len(self.oams_names))]
+        self.pin_names = config.getlist('pins', default_pins)
+        expected = 8 * len(self.oams_names)
+        if len(self.pin_names) != expected:
+            raise config.error(
+                f'pins option must contain {expected} pin names')
+        # automatically create virtual pins for any missing entries
+        virtual_input_pin.add_printer_objects(config)
+        chip = self.printer.lookup_object('virtual_pin_chip')
+        for name in self.pin_names:
+            if name in chip.pins:
+                continue
+            vcfg = _VPinConfig(self.printer, name)
+            virtual_input_pin.VirtualInputPin(vcfg)
         self.timer = self.reactor.register_timer(self._sync_event)
         self.printer.register_event_handler('klippy:ready', self.handle_ready)
 
@@ -28,43 +68,24 @@ class AutoAMSUpdate:
 
     def _sync_event(self, eventtime):
         try:
-            oams1 = self.printer.lookup_object('oams ' + self.oams1_name, None)
-            oams2 = self.printer.lookup_object('oams ' + self.oams2_name, None)
-            vals1 = getattr(oams1, 'f1s_hes_value', [0,0,0,0]) if oams1 else [0,0,0,0]
-            vals2 = getattr(oams2, 'f1s_hes_value', [0,0,0,0]) if oams2 else [0,0,0,0]
-            hubs1 = getattr(oams1, 'hub_hes_value', [0,0,0,0]) if oams1 else [0,0,0,0]
-            hubs2 = getattr(oams2, 'hub_hes_value', [0,0,0,0]) if oams2 else [0,0,0,0]
-            class GC:
-                def __init__(self, val):
-                    self.val = val
-                def get_int(self, name, default=None):
-                    return self.val if name == 'VALUE' else default
-            # f1s_hes values -> pins1..8
-            for i in range(4):
-                pin = self.pin_names[i]
-                val = int(vals1[i])
-                cmd = self.gcode.commands.get(('SET_VIRTUAL_PIN', pin))
-                if cmd is not None:
-                    cmd(GC(val))
-            for i in range(4):
-                pin = self.pin_names[i+4]
-                val = int(vals2[i])
-                cmd = self.gcode.commands.get(('SET_VIRTUAL_PIN', pin))
-                if cmd is not None:
-                    cmd(GC(val))
-            # hub_hes values -> pins9..16
-            for i in range(4):
-                pin = self.pin_names[i+8]
-                val = int(hubs1[i])
-                cmd = self.gcode.commands.get(('SET_VIRTUAL_PIN', pin))
-                if cmd is not None:
-                    cmd(GC(val))
-            for i in range(4):
-                pin = self.pin_names[i+12]
-                val = int(hubs2[i])
-                cmd = self.gcode.commands.get(('SET_VIRTUAL_PIN', pin))
-                if cmd is not None:
-                    cmd(GC(val))
+            # Lookup all configured AMS objects
+            oams_objs = [
+                self.printer.lookup_object('oams ' + name, None)
+                for name in self.oams_names
+            ]
+            def update_pin(name, value):
+                cmdline = f"SET_VIRTUAL_PIN PIN={name} VALUE={int(value)}"
+                self.gcode.run_script_from_command(cmdline)
+            num = len(oams_objs)
+            lane_offset = 0
+            hub_offset = 4 * num
+            for idx, oams in enumerate(oams_objs):
+                vals = getattr(oams, 'f1s_hes_value', [0,0,0,0]) if oams else [0,0,0,0]
+                hubs = getattr(oams, 'hub_hes_value', [0,0,0,0]) if oams else [0,0,0,0]
+                for i in range(4):
+                    update_pin(self.pin_names[lane_offset + idx*4 + i], vals[i])
+                for i in range(4):
+                    update_pin(self.pin_names[hub_offset + idx*4 + i], hubs[i])
         except Exception:
             logging.exception('auto AMS update error')
         return eventtime + self.interval


### PR DESCRIPTION
## Summary
- document AMS virtual pin configuration with descriptive pin names
- auto_ams_update detects multiple `oams#` sections and updates corresponding pins
- auto_ams_update creates missing `virtual_input_pin` entries for configured AMS pins

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688c4ecaf0448326a396c68d3dc979fc