### PR TITLE
Add AFC_AMS module for OpenAMS integration

### DIFF
--- a/AFC-Klipper-Add-On/extras/AFC_AMS.py
+++ b/AFC-Klipper-Add-On/extras/AFC_AMS.py
@@ -1,0 +1,75 @@
+# Armored Turtle Automated Filament Control - OpenAMS integration
+#
+# Copyright (C) 2025 Armored Turtle
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+import traceback
+
+from configparser import Error as error
+
+try:
+    from extras.AFC_utils import ERROR_STR
+except Exception:
+    raise error(
+        "Error when trying to import AFC_utils.ERROR_STR\n{trace}".format(
+            trace=traceback.format_exc()
+        )
+    )
+
+try:
+    from extras.AFC_BoxTurtle import afcBoxTurtle
+except Exception:
+    raise error(
+        ERROR_STR.format(import_lib="AFC_BoxTurtle", trace=traceback.format_exc())
+    )
+
+
+SYNC_INTERVAL = 2.0
+
+
+class afcAMS(afcBoxTurtle):
+    """AFC unit that syncs lane and hub sensors directly from OpenAMS."""
+
+    def __init__(self, config):
+        super().__init__(config)
+        self.type = config.get("type", "AMS")
+        self.oams_name = config.get("oams", "oams1")
+        self.interval = config.getfloat("interval", SYNC_INTERVAL, above=0.0)
+        self.reactor = self.printer.get_reactor()
+        self.oams = None
+        self.timer = self.reactor.register_timer(self._sync_event)
+        self.last_lane_vals = [None] * 4
+        self.last_hub_vals = [None] * 4
+        self.printer.register_event_handler("klippy:ready", self.handle_ready)
+
+    def handle_ready(self):
+        self.oams = self.printer.lookup_object("oams " + self.oams_name, None)
+        self.reactor.update_timer(self.timer, self.reactor.NOW)
+
+    def _sync_event(self, eventtime):
+        try:
+            if self.oams is None:
+                self.oams = self.printer.lookup_object("oams " + self.oams_name, None)
+                if self.oams is None:
+                    return eventtime + self.interval
+            f1s = getattr(self.oams, "f1s_hes_value", [0, 0, 0, 0])
+            hubs = getattr(self.oams, "hub_hes_value", [0, 0, 0, 0])
+            for lane in self.lanes.values():
+                idx = getattr(lane, "index", 0)
+                lane_state = bool(f1s[idx])
+                if self.last_lane_vals[idx] != lane_state:
+                    lane.prep_callback(eventtime, lane_state)
+                    lane.load_callback(eventtime, lane_state)
+                    self.last_lane_vals[idx] = lane_state
+                hub_state = bool(hubs[idx])
+                hub = lane.hub_obj
+                if hub is not None and self.last_hub_vals[idx] != hub_state:
+                    hub.switch_pin_callback(eventtime, hub_state)
+                    self.last_hub_vals[idx] = hub_state
+        except Exception:
+            self.logger.exception("AFC_AMS update error")
+        return eventtime + self.interval
+
+
+def load_config_prefix(config):
+    return afcAMS(config)

--- a/AFC-Klipper-Add-On/extras/AFC_hub.py
+++ b/AFC-Klipper-Add-On/extras/AFC_hub.py
@@ -27,7 +27,7 @@ class afc_hub:
 
         # HUB Cut variables
         # Next two variables are used in AFC
-        self.switch_pin             = config.get('switch_pin')                      # Pin hub sensor it connected to
+        self.switch_pin             = config.get('switch_pin', None)                 # Pin hub sensor it connected to
         self.hub_clear_move_dis     = config.getfloat("hub_clear_move_dis", 25)     # How far to move filament so that it's not block the hub exit
         self.afc_bowden_length      = config.getfloat("afc_bowden_length", 900)     # Length of the Bowden tube from the hub to the toolhead sensor in mm.
         self.afc_unload_bowden_length= config.getfloat("afc_unload_bowden_length", self.afc_bowden_length) # Length to unload when retracting back from toolhead to hub in mm. Defaults to afc_bowden_length
@@ -47,17 +47,21 @@ class afc_hub:
 
         self.config_bowden_length   = self.afc_bowden_length                        # Used by SET_BOWDEN_LENGTH macro
         self.config_unload_bowden_length = self.afc_unload_bowden_length
-        self.enable_sensors_in_gui  = config.getboolean("enable_sensors_in_gui", self.afc.enable_sensors_in_gui) # Set to True to show hub sensor switche as filament sensor in mainsail/fluidd gui, overrides value set in AFC.cfg
+        self.enable_sensors_in_gui  = (
+            config.getboolean("enable_sensors_in_gui", self.afc.enable_sensors_in_gui)
+            if self.switch_pin is not None
+            else False
+        )  # Show hub switch in gui when pin present
 
-        buttons = self.printer.load_object(config, "buttons")
         if self.switch_pin is not None:
+            buttons = self.printer.load_object(config, "buttons")
             self.state = False
             buttons.register_buttons([self.switch_pin], self.switch_pin_callback)
-
-
-        if self.enable_sensors_in_gui:
-            self.filament_switch_name = "filament_switch_sensor {}_Hub".format(self.name)
-            self.fila = add_filament_switch(self.filament_switch_name, self.switch_pin, self.printer )
+            if self.enable_sensors_in_gui:
+                self.filament_switch_name = "filament_switch_sensor {}_Hub".format(self.name)
+                self.fila = add_filament_switch(
+                    self.filament_switch_name, self.switch_pin, self.printer
+                )
 
         # Adding self to AFC hubs
         self.afc.hubs[self.name]=self


### PR DESCRIPTION
## Summary
- add new `AFC_AMS` unit that polls OpenAMS for lane and hub sensor states
- start timer on ready to sync `f1s_hes_value` and `hub_hes_value` to AFC lanes and hubs

## Testing
- `python -m py_compile AFC-Klipper-Add-On/extras/AFC_AMS.py`


------
https://chatgpt.com/codex/tasks/task_e_68bd15eca60c832694dfb41c2adbd499