### PR TITLE
Add AMS unit integrating OpenAMS

### DIFF
--- a/AFC-Klipper-Add-On/extras/AFC_AMS.py
+++ b/AFC-Klipper-Add-On/extras/AFC_AMS.py
@@ -1,0 +1,81 @@
+# Armored Turtle Automated Filament Control - AMS integration
+#
+# Copyright (C) 2025
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+
+import traceback
+
+from configparser import Error as error
+
+try:
+    from extras.AFC_unit import afcUnit
+except Exception:
+    raise error("Error when trying to import AFC_unit\n{trace}".format(trace=traceback.format_exc()))
+
+SYNC_INTERVAL = 2.0
+
+
+class afcAMS(afcUnit):
+    """AFK unit that synchronizes lane and hub states with OpenAMS."""
+
+    def __init__(self, config):
+        super().__init__(config)
+        self.type = "AMS"
+        self.oams_name = config.get("oams", "oams1")
+        self.interval = config.getfloat("interval", SYNC_INTERVAL, above=0.0)
+
+        self.reactor = self.printer.get_reactor()
+        self.timer = self.reactor.register_timer(self._sync_event)
+        self.printer.register_event_handler("klippy:ready", self.handle_ready)
+
+        # Track last sensor states so callbacks only trigger on changes
+        self._last_lane_states = {}
+        self._last_hub_states = {}
+
+    def handle_connect(self):
+        """Ensure base AFC connectivity."""
+        super().handle_connect()
+
+    def handle_ready(self):
+        # Resolve OpenAMS object and start periodic polling
+        self.oams = self.printer.lookup_object("oams " + self.oams_name, None)
+        self.reactor.update_timer(self.timer, self.reactor.NOW)
+
+    def _sync_event(self, eventtime):
+        try:
+            if self.oams is None:
+                return eventtime + self.interval
+
+            # Iterate through lanes belonging to this unit
+            for lane in list(self.lanes.values()):
+                idx = getattr(lane, "index", 0) - 1
+                if idx < 0:
+                    continue
+
+                lane_val = bool(self.oams.f1s_hes_value[idx])
+                last_lane = self._last_lane_states.get(lane.name)
+                if lane_val != last_lane:
+                    lane.load_callback(eventtime, lane_val)
+                    lane.prep_callback(eventtime, lane_val)
+                    self._last_lane_states[lane.name] = lane_val
+
+                hub = getattr(lane, "hub_obj", None)
+                if hub is None:
+                    continue
+
+                hub_val = bool(self.oams.hub_hes_value[idx])
+                last_hub = self._last_hub_states.get(hub.name)
+                if hub_val != last_hub:
+                    hub.switch_pin_callback(eventtime, hub_val)
+                    self._last_hub_states[hub.name] = hub_val
+
+        except Exception:
+            # Avoid breaking the reactor loop if OpenAMS query fails
+            pass
+
+        return eventtime + self.interval
+
+
+def load_config_prefix(config):
+    return afcAMS(config)

--- a/AFC-Klipper-Add-On/extras/AFC_hub.py
+++ b/AFC-Klipper-Add-On/extras/AFC_hub.py
@@ -27,7 +27,7 @@ class afc_hub:
 
         # HUB Cut variables
         # Next two variables are used in AFC
-        self.switch_pin             = config.get('switch_pin')                      # Pin hub sensor it connected to
+        self.switch_pin             = config.get('switch_pin', None)                # Pin hub sensor it connected to
         self.hub_clear_move_dis     = config.getfloat("hub_clear_move_dis", 25)     # How far to move filament so that it's not block the hub exit
         self.afc_bowden_length      = config.getfloat("afc_bowden_length", 900)     # Length of the Bowden tube from the hub to the toolhead sensor in mm.
         self.afc_unload_bowden_length= config.getfloat("afc_unload_bowden_length", self.afc_bowden_length) # Length to unload when retracting back from toolhead to hub in mm. Defaults to afc_bowden_length
@@ -50,12 +50,14 @@ class afc_hub:
         self.enable_sensors_in_gui  = config.getboolean("enable_sensors_in_gui", self.afc.enable_sensors_in_gui) # Set to True to show hub sensor switche as filament sensor in mainsail/fluidd gui, overrides value set in AFC.cfg
 
         buttons = self.printer.load_object(config, "buttons")
-        if self.switch_pin is not None:
+        if self.switch_pin not in (None, "None", ""):
             self.state = False
             buttons.register_buttons([self.switch_pin], self.switch_pin_callback)
+        else:
+            self.switch_pin = None
 
 
-        if self.enable_sensors_in_gui:
+        if self.enable_sensors_in_gui and self.switch_pin:
             self.filament_switch_name = "filament_switch_sensor {}_Hub".format(self.name)
             self.fila = add_filament_switch(self.filament_switch_name, self.switch_pin, self.printer )
 

--- a/printer_data/config/AFC/AFC_AMS1.cfg
+++ b/printer_data/config/AFC/AFC_AMS1.cfg
@@ -2,14 +2,12 @@
 
 
 
-[AFC_BoxTurtle AMS_1]
-#oams: oams1
+[AFC_AMS AMS1]
+oams: oams1
 extruder: extruder4
 
 [AFC_lane lane4]
-unit: AMS_1:1
-prep: virtual_pin:ams1lane0pl
-load: virtual_pin:ams1lane0pl
+unit: AMS1:1
 # prep: ams1lane0pl
 # load: ams1lane0pl
 load_to_hub: False
@@ -22,9 +20,7 @@ custom_unload_cmd: SAFE_UNLOAD_FILAMENT1
 extruder: extruder4
 
 [AFC_lane lane6]
-unit: AMS_1:2
-prep: virtual_pin:ams1lane1pl
-load: virtual_pin:ams1lane1pl
+unit: AMS1:2
 # prep: ams1lane1pl
 # load: ams1lane1pl
 load_to_hub: False
@@ -37,9 +33,7 @@ custom_unload_cmd: SAFE_UNLOAD_FILAMENT1
 extruder: extruder4
 
 [AFC_lane lane7]
-unit: AMS_1:3
-prep: virtual_pin:ams1lane2pl
-load: virtual_pin:ams1lane2pl
+unit: AMS1:3
 # prep: ams1lane2pl
 # load: ams1lane2pl
 load_to_hub: False
@@ -52,9 +46,7 @@ custom_unload_cmd: SAFE_UNLOAD_FILAMENT1
 extruder: extruder4
 
 [AFC_lane lane8]
-unit: AMS_1:4
-prep: virtual_pin:ams1lane3pl
-load: virtual_pin:ams1lane3pl
+unit: AMS1:4
 # prep: ams1lane3pl
 # load: ams1lane3pl
 load_to_hub: False
@@ -67,7 +59,6 @@ custom_unload_cmd: SAFE_UNLOAD_FILAMENT1
 extruder: extruder4
 
 [AFC_hub Hub_1]
-switch_pin: ^virtual_pin:ams1hub0   # Pin for the hub switch
 #switch_pin: ^ams1hub0   # Pin for the hub switch
 afc_bowden_length: 1725     # Length of the Bowden tube from the hub to the toolhead sensor in mm.
 move_dis: 50                # Distance to move the filament within the hub in mm.
@@ -75,7 +66,6 @@ move_dis: 50                # Distance to move the filament within the hub in mm
 cut: False                  # Hub cutter installed (e.g. Snappy)
 
 [AFC_hub Hub_2]
-switch_pin: ^virtual_pin:ams1hub1   # Pin for the hub switch
 #switch_pin: ^ams1hub1   # Pin for the hub switch
 afc_bowden_length: 1725     # Length of the Bowden tube from the hub to the toolhead sensor in mm.
 move_dis: 50                # Distance to move the filament within the hub in mm.
@@ -83,7 +73,6 @@ move_dis: 50                # Distance to move the filament within the hub in mm
 cut: False  
 
 [AFC_hub Hub_3]
-switch_pin: ^virtual_pin:ams1hub2   # Pin for the hub switch
 #switch_pin: ^ams1hub2   # Pin for the hub switch
 afc_bowden_length: 1725     # Length of the Bowden tube from the hub to the toolhead sensor in mm.
 move_dis: 50                # Distance to move the filament within the hub in mm.
@@ -91,7 +80,6 @@ move_dis: 50                # Distance to move the filament within the hub in mm
 cut: False  
 
 [AFC_hub Hub_4]
-switch_pin: ^virtual_pin:ams1hub3   # Pin for the hub switch
 #switch_pin: ^ams1hub3   # Pin for the hub switch
 afc_bowden_length: 1725     # Length of the Bowden tube from the hub to the toolhead sensor in mm.
 move_dis: 50                # Distance to move the filament within the hub in mm.

--- a/printer_data/config/AFC/AFC_AMS2.cfg
+++ b/printer_data/config/AFC/AFC_AMS2.cfg
@@ -11,16 +11,14 @@ release_gcode:
     {% endif %}
   {% endif %}
 
-[AFC_BoxTurtle AMS_2]
-#oams: oams2
+[AFC_AMS AMS2]
+oams: oams2
 extruder: extruder5
 
 
 
 [AFC_lane lane5]
-unit: AMS_2:1
-prep: virtual_pin:ams2lane0pl
-load: virtual_pin:ams2lane0pl
+unit: AMS2:1
 # prep: ams2lane0pl
 # load: ams2lane0pl
 # load_to_hub: False
@@ -33,9 +31,7 @@ custom_unload_cmd: SAFE_UNLOAD_FILAMENT2
 extruder: extruder5
 
 [AFC_lane lane9]
-unit: AMS_2:2
-prep: virtual_pin:ams2lane1pl
-load: virtual_pin:ams2lane1pl
+unit: AMS2:2
 # prep: ams2lane1pl
 # load: ams2lane1pl
 load_to_hub: False
@@ -48,9 +44,7 @@ custom_unload_cmd: SAFE_UNLOAD_FILAMENT2
 extruder: extruder5
 
 [AFC_lane lane10]
-unit: AMS_2:3
-prep: virtual_pin:ams2lane2pl
-load: virtual_pin:ams2lane2pl
+unit: AMS2:3
 # prep: ams2lane2pl
 # load: ams2lane2pl
 load_to_hub: False
@@ -63,9 +57,7 @@ custom_unload_cmd: SAFE_UNLOAD_FILAMENT2
 extruder: extruder5
 
 [AFC_lane lane11]
-unit: AMS_2:4
-prep: virtual_pin:ams2lane3pl
-load: virtual_pin:ams2lane3pl
+unit: AMS2:4
 # prep: ams2lane3pl
 # load: ams2lane3pl
 load_to_hub: False
@@ -78,7 +70,6 @@ custom_unload_cmd: SAFE_UNLOAD_FILAMENT2
 extruder: extruder5
 
 [AFC_hub Hub_5]
-switch_pin: ^virtual_pin:ams2hub0   # Pin for the hub switch
 #switch_pin: ^ams2hub0   # Pin for the hub switch
 afc_bowden_length: 1725     # Length of the Bowden tube from the hub to the toolhead sensor in mm.
 move_dis: 50                # Distance to move the filament within the hub in mm.
@@ -86,7 +77,6 @@ move_dis: 50                # Distance to move the filament within the hub in mm
 cut: False  
 
 [AFC_hub Hub_6]
-switch_pin: ^virtual_pin:ams2hub1   # Pin for the hub switch
 #switch_pin: ^ams2hub1   # Pin for the hub switch
 afc_bowden_length: 1725     # Length of the Bowden tube from the hub to the toolhead sensor in mm.
 move_dis: 50                # Distance to move the filament within the hub in mm.
@@ -94,7 +84,6 @@ move_dis: 50                # Distance to move the filament within the hub in mm
 cut: False  
 
 [AFC_hub Hub_7]
-switch_pin: ^virtual_pin:ams2hub2   # Pin for the hub switch
 #switch_pin: ^ams2hub2   # Pin for the hub switch
 afc_bowden_length: 1725     # Length of the Bowden tube from the hub to the toolhead sensor in mm.
 move_dis: 50                # Distance to move the filament within the hub in mm.
@@ -102,7 +91,6 @@ move_dis: 50                # Distance to move the filament within the hub in mm
 cut: False  
 
 [AFC_hub Hub_8]
-switch_pin: ^virtual_pin:ams2hub3   # Pin for the hub switch
 #switch_pin: ^ams2hub3   # Pin for the hub switch
 afc_bowden_length: 1725     # Length of the Bowden tube from the hub to the toolhead sensor in mm.
 move_dis: 50                # Distance to move the filament within the hub in mm.


### PR DESCRIPTION
## Summary
- add `AFC_AMS` unit module that polls OpenAMS and updates lanes and hubs
- allow hubs without hardware switch pins
- configure AMS units to use direct OpenAMS data instead of virtual pins

## Testing
- `python -m py_compile AFC-Klipper-Add-On/extras/AFC_AMS.py AFC-Klipper-Add-On/extras/AFC_hub.py`


------
https://chatgpt.com/codex/tasks/task_e_68bd15eca60c832694dfb41c2adbd499