### PR TITLE
Register AMS hub with virtual pin

### DIFF
--- a/klipper/klippy/extras/AFC_AMS.py
+++ b/klipper/klippy/extras/AFC_AMS.py
@@ -17,6 +17,71 @@ try:
 except Exception:
     raise error("Error when trying to import AFC_lane\n{trace}".format(trace=traceback.format_exc()))
 
+# -----------------------------------------------------------------------------
+# Monkey patch afc_hub to allow virtual switch pins for AMS hubs
+# -----------------------------------------------------------------------------
+try:
+    import extras.AFC_hub as _AFC_HUB
+
+    def _patched_hub_init(self, config):
+        self.printer = config.get_printer()
+        self.printer.register_event_handler("klippy:connect", self.handle_connect)
+        self.afc = self.printer.lookup_object('AFC')
+        self.fullname = config.get_name()
+        self.name = self.fullname.split()[-1]
+
+        self.unit = None
+        self.lanes = {}
+        self.state = False
+
+        # HUB Cut variables
+        # Next two variables are used in AFC
+        self.switch_pin = config.get('switch_pin', None)
+        self.hub_clear_move_dis = config.getfloat("hub_clear_move_dis", 25)
+        self.afc_bowden_length = config.getfloat("afc_bowden_length", 900)
+        self.afc_unload_bowden_length = config.getfloat(
+            "afc_unload_bowden_length", self.afc_bowden_length)
+        self.assisted_retract = config.getboolean("assisted_retract", False)
+        self.move_dis = config.getfloat("move_dis", 50)
+        # Servo settings
+        self.cut = config.getboolean("cut", False)
+        self.cut_cmd = config.get('cut_cmd', None)
+        self.cut_servo_name = config.get('cut_servo_name', 'cut')
+        self.cut_dist = config.getfloat("cut_dist", 50)
+        self.cut_clear = config.getfloat("cut_clear", 120)
+        self.cut_min_length = config.getfloat("cut_min_length", 200)
+        self.cut_servo_pass_angle = config.getfloat("cut_servo_pass_angle", 0)
+        self.cut_servo_clip_angle = config.getfloat("cut_servo_clip_angle", 160)
+        self.cut_servo_prep_angle = config.getfloat("cut_servo_prep_angle", 75)
+        self.cut_confirm = config.getboolean("cut_confirm", 0)
+
+        self.config_bowden_length = self.afc_bowden_length
+        self.config_unload_bowden_length = self.afc_unload_bowden_length
+        self.enable_sensors_in_gui = config.getboolean(
+            "enable_sensors_in_gui", self.afc.enable_sensors_in_gui)
+
+        buttons = self.printer.load_object(config, "buttons")
+        if self.switch_pin in (None, "None", ""):
+            # Create a virtual pin so the hub can be referenced without
+            # requiring a physical switch pin in the config.
+            self.switch_pin = f"afc_virtual_bypass:hub_{self.name}"
+        self.state = False
+        buttons.register_buttons([self.switch_pin], self.switch_pin_callback)
+
+        if self.enable_sensors_in_gui:
+            self.filament_switch_name = (
+                "filament_switch_sensor {}_Hub".format(self.name))
+            self.fila = _AFC_HUB.add_filament_switch(
+                self.filament_switch_name, self.switch_pin, self.printer)
+
+        # Adding self to AFC hubs
+        self.afc.hubs[self.name] = self
+
+    _AFC_HUB.afc_hub.__init__ = _patched_hub_init
+except Exception:
+    # If the hub module isn't present we silently ignore the patch
+    pass
+
 SYNC_INTERVAL = 2.0
 
 
@@ -160,6 +225,9 @@ class afcAMS(afcUnit):
                 last_hub = self._last_hub_states.get(hub.name)
                 if hub_val != last_hub:
                     hub.switch_pin_callback(eventtime, hub_val)
+                    if hasattr(hub, "fila"):
+                        hub.fila.runout_helper.note_filament_present(
+                            eventtime, hub_val)
                     self._last_hub_states[hub.name] = hub_val
 
         except Exception:


### PR DESCRIPTION
## Summary
- Provide virtual `afc_virtual_bypass` pin when hub switch pin is omitted
- Forward AMS hub state to the associated filament sensor

## Testing
- `python -m py_compile klipper/klippy/extras/AFC_AMS.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd84dfd6f48326839d67982acbcbe0