### PR TITLE
Retry unload macros on OAMS jam

### DIFF
--- a/printer_data/config/oams_macros.cfg
+++ b/printer_data/config/oams_macros.cfg
@@ -68,6 +68,7 @@
 [gcode_macro SAFE_UNLOAD_FILAMENT1]
 
 variable_pause_triggered = False
+variable_retry = 0
 
 gcode:
     {% set UNLOAD_SPEED = 1000 %}
@@ -112,6 +113,17 @@ gcode:
       #G4 P1000
       OAMSM_UNLOAD_FILAMENT FPS=fps1
       M400
+      {% set oams_name = printer['oams_manager']['fps fps1'].current_oams %}
+      {% if oams_name is not none %}
+        {% set error_code = printer['oams_manager'].oams[oams_name].action_status_code|int %}
+        {% if error_code == 3 and retry == 0 %}
+          OAMSM_CLEAR_ERRORS
+          SET_GCODE_VARIABLE MACRO=SAFE_UNLOAD_FILAMENT1 VARIABLE=retry VALUE=1
+          SAFE_UNLOAD_FILAMENT1
+        {% else %}
+          SET_GCODE_VARIABLE MACRO=SAFE_UNLOAD_FILAMENT1 VARIABLE=retry VALUE=0
+        {% endif %}
+      {% endif %}
      # SELECT_TOOL T=4
     {% endif %}
 
@@ -119,6 +131,7 @@ gcode:
 [gcode_macro SAFE_UNLOAD_FILAMENT2]
 
 variable_pause_triggered = False
+variable_retry = 0
 
 gcode:
     {% set UNLOAD_SPEED = 1000 %}
@@ -163,6 +176,17 @@ gcode:
      # G4 P1000
       OAMSM_UNLOAD_FILAMENT FPS=fps2
       M400
+      {% set oams_name = printer['oams_manager']['fps fps2'].current_oams %}
+      {% if oams_name is not none %}
+        {% set error_code = printer['oams_manager'].oams[oams_name].action_status_code|int %}
+        {% if error_code == 3 and retry == 0 %}
+          OAMSM_CLEAR_ERRORS
+          SET_GCODE_VARIABLE MACRO=SAFE_UNLOAD_FILAMENT2 VARIABLE=retry VALUE=1
+          SAFE_UNLOAD_FILAMENT2
+        {% else %}
+          SET_GCODE_VARIABLE MACRO=SAFE_UNLOAD_FILAMENT2 VARIABLE=retry VALUE=0
+        {% endif %}
+      {% endif %}
     #  SELECT_TOOL T=5
     {% endif %}
     


### PR DESCRIPTION
## Summary
- retry SAFE_UNLOAD_FILAMENT1 and SAFE_UNLOAD_FILAMENT2 if OAMS reports jam error 3
- clear OAMS errors before retrying and reset retry flag

## Testing
- `python -m compileall -q .`


------
https://chatgpt.com/codex/tasks/task_e_68c1aa5bb9d88326a12a52c1789c10d4