### PR TITLE
Retry unload on OAMS error 3

### DIFF
--- a/klipper_openams/src/oams_manager.py
+++ b/klipper_openams/src/oams_manager.py
@@ -268,14 +268,19 @@ class OAMSManager:
             - state_name: Loading state (LOADED/UNLOADED/LOADING/UNLOADING)
             - since: Timestamp when current state began
         """
-        attributes = {}
+        attributes = {
+            "oams": {
+                name: {"action_status_code": oam.action_status_code}
+                for name, oam in self.oams.items()
+            }
+        }
         for fps_name, fps_state in self.current_state.fps_state.items():
             attributes[fps_name] = {
                 "current_group": fps_state.current_group,
                 "current_oams": fps_state.current_oams,
                 "current_spool_idx": fps_state.current_spool_idx,
                 "state_name": fps_state.state_name,
-                "since": fps_state.since
+                "since": fps_state.since,
             }
         return attributes
     

--- a/printer_data/config/oams_macros.cfg
+++ b/printer_data/config/oams_macros.cfg
@@ -68,6 +68,7 @@
 [gcode_macro SAFE_UNLOAD_FILAMENT1]
 
 variable_pause_triggered = False
+variable_retry = 0
 
 gcode:
     {% set UNLOAD_SPEED = 1000 %}
@@ -112,6 +113,14 @@ gcode:
       #G4 P1000
       OAMSM_UNLOAD_FILAMENT FPS=fps1
       M400
+      {% if printer['oams_manager'].oams['oams1'].action_status_code == 3 and printer['gcode_macro SAFE_UNLOAD_FILAMENT1'].retry|int == 0 %}
+        RESPOND TYPE=command MSG='OAMS error 3 detected, retrying unload'
+        OAMSM_CLEAR_ERRORS
+        SET_GCODE_VARIABLE MACRO=SAFE_UNLOAD_FILAMENT1 VARIABLE=retry VALUE=1
+        SAFE_UNLOAD_FILAMENT1
+      {% else %}
+        SET_GCODE_VARIABLE MACRO=SAFE_UNLOAD_FILAMENT1 VARIABLE=retry VALUE=0
+      {% endif %}
      # SELECT_TOOL T=4
     {% endif %}
 
@@ -119,6 +128,7 @@ gcode:
 [gcode_macro SAFE_UNLOAD_FILAMENT2]
 
 variable_pause_triggered = False
+variable_retry = 0
 
 gcode:
     {% set UNLOAD_SPEED = 1000 %}
@@ -163,6 +173,14 @@ gcode:
      # G4 P1000
       OAMSM_UNLOAD_FILAMENT FPS=fps2
       M400
+      {% if printer['oams_manager'].oams['oams2'].action_status_code == 3 and printer['gcode_macro SAFE_UNLOAD_FILAMENT2'].retry|int == 0 %}
+        RESPOND TYPE=command MSG='OAMS error 3 detected, retrying unload'
+        OAMSM_CLEAR_ERRORS
+        SET_GCODE_VARIABLE MACRO=SAFE_UNLOAD_FILAMENT2 VARIABLE=retry VALUE=1
+        SAFE_UNLOAD_FILAMENT2
+      {% else %}
+        SET_GCODE_VARIABLE MACRO=SAFE_UNLOAD_FILAMENT2 VARIABLE=retry VALUE=0
+      {% endif %}
     #  SELECT_TOOL T=5
     {% endif %}
     


### PR DESCRIPTION
## Summary
- retry SAFE_UNLOAD_FILAMENT1 and SAFE_UNLOAD_FILAMENT2 if OAMS reports error 3
- clear OAMS errors before retrying to allow a second attempt
- expose OAMS action status codes through `oams_manager` for macro checks
- reference OAMS objects via `oams_manager` to avoid undefined attribute errors

## Testing
- `python -m py_compile klipper_openams/src/oams.py klipper_openams/src/oams_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_68c1aa5bb9d88326a12a52c1789c10d4