### PR TITLE
Integrate AMS runout handling into AFC

### DIFF
--- a/klipper/klippy/extras/AFC_AMS.py
+++ b/klipper/klippy/extras/AFC_AMS.py
@@ -211,6 +211,13 @@ class afcAMS(afcUnit):
             if self.oams is None:
                 return eventtime + self.interval
 
+            # Request updated sensor values from the OpenAMS controller so
+            # new spools inserted into empty bays are detected.
+            try:
+                self.oams.determine_current_spool()
+            except Exception:
+                pass
+
             # Iterate through lanes belonging to this unit
             for lane in list(self.lanes.values()):
                 idx = getattr(lane, "index", 0) - 1


### PR DESCRIPTION
## Summary
- Centralize filament runout handling inside AFC
- Remove OpenAMS runout monitor and rely on AFC lane logic
- Allow AMS units to trigger infinite spool or pause via unified runout path
- Guard load runout handling for lanes without physical sensors

## Testing
- `python -m py_compile AFC-Klipper-Add-On/extras/AFC_lane.py klipper/klippy/extras/AFC_AMS.py klipper_openams/src/oams_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_68c30425e528832697d730ab88dc467a