### PR TITLE
Integrate AMS runout handling into AFC

### DIFF
--- a/klipper/klippy/extras/AFC_AMS.py
+++ b/klipper/klippy/extras/AFC_AMS.py
@@ -99,7 +99,8 @@ class afcAMS(afcUnit):
         self.printer.register_event_handler("klippy:ready", self.handle_ready)
 
         # Track last sensor states so callbacks only trigger on changes
-        self._last_lane_states = {}
+        self._last_prep_states = {}
+        self._last_load_states = {}
         self._last_hub_states = {}
 
     def handle_connect(self):
@@ -194,6 +195,13 @@ class afcAMS(afcUnit):
 
         return succeeded
 
+    def check_runout(self, cur_lane):
+        """Determine if runout logic should trigger for the current lane."""
+        return (cur_lane.name == self.afc.function.get_current_lane()
+                and self.afc.function.is_printing()
+                and cur_lane.status not in (AFCLaneState.EJECTING,
+                                            AFCLaneState.CALIBRATING))
+
     def handle_ready(self):
         # Resolve OpenAMS object and start periodic polling
         self.oams = self.printer.lookup_object("oams " + self.oams_name, None)
@@ -204,31 +212,45 @@ class afcAMS(afcUnit):
             if self.oams is None:
                 return eventtime + self.interval
 
+            # Request updated sensor values from the OpenAMS controller so
+            # new spools inserted into empty bays are detected.
+            try:
+                self.oams.determine_current_spool()
+            except Exception:
+                pass
+
             # Iterate through lanes belonging to this unit
             for lane in list(self.lanes.values()):
                 idx = getattr(lane, "index", 0) - 1
                 if idx < 0:
                     continue
 
-                lane_val = bool(self.oams.f1s_hes_value[idx])
-                last_lane = self._last_lane_states.get(lane.name)
-                if lane_val != last_lane:
-                    lane.load_callback(eventtime, lane_val)
-                    lane.prep_callback(eventtime, lane_val)
-                    self._last_lane_states[lane.name] = lane_val
+                # OpenAMS exposes separate sensors for spool presence (prep)
+                # and filament loaded into the hub (load). Track changes for
+                # each independently so lane callbacks mirror physical state.
+                prep_val = bool(self.oams.f1s_hes_value[idx])
+                last_prep = self._last_prep_states.get(lane.name)
+                if prep_val != last_prep:
+                    lane.prep_callback(eventtime, prep_val)
+                    self._last_prep_states[lane.name] = prep_val
+
+                load_val = bool(self.oams.hub_hes_value[idx])
+                last_load = self._last_load_states.get(lane.name)
+                if load_val != last_load:
+                    lane.handle_load_runout(eventtime, load_val)
+                    self._last_load_states[lane.name] = load_val
 
                 hub = getattr(lane, "hub_obj", None)
                 if hub is None:
                     continue
 
-                hub_val = bool(self.oams.hub_hes_value[idx])
                 last_hub = self._last_hub_states.get(hub.name)
-                if hub_val != last_hub:
-                    hub.switch_pin_callback(eventtime, hub_val)
+                if load_val != last_hub:
+                    hub.switch_pin_callback(eventtime, load_val)
                     if hasattr(hub, "fila"):
                         hub.fila.runout_helper.note_filament_present(
-                            eventtime, hub_val)
-                    self._last_hub_states[hub.name] = hub_val
+                            eventtime, load_val)
+                    self._last_hub_states[hub.name] = load_val
 
         except Exception:
             # Avoid breaking the reactor loop if OpenAMS query fails


### PR DESCRIPTION
## Summary
- Centralize filament runout handling inside AFC
- Remove OpenAMS runout monitor and rely on AFC lane logic
- Allow AMS units to trigger infinite spool or pause via unified runout path
- Guard load runout handling for lanes without physical sensors
- Poll OpenAMS sensors during sync so newly loaded spools are detected
- Track AMS prep and hub sensors separately to update lanes when spools are added or removed

## Testing
- `python -m py_compile AFC-Klipper-Add-On/extras/AFC_lane.py klipper/klippy/extras/AFC_AMS.py klipper_openams/src/oams_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_68c30425e528832697d730ab88dc467a