### PR TITLE
Integrate OpenAMS runout callbacks with AFC

### DIFF
--- a/klipper/klippy/extras/AFC_AMS.py
+++ b/klipper/klippy/extras/AFC_AMS.py
@@ -93,6 +93,7 @@ class afcAMS(afcUnit):
         self.type = "AMS"
         self.oams_name = config.get("oams", "oams1")
         self.interval = config.getfloat("interval", SYNC_INTERVAL, above=0.0)
+        self.oams_manager = None
 
         self.reactor = self.printer.get_reactor()
         self.timer = self.reactor.register_timer(self._sync_event)
@@ -202,59 +203,111 @@ class afcAMS(afcUnit):
                 and cur_lane.status not in (AFCLaneState.EJECTING,
                                             AFCLaneState.CALIBRATING))
 
+    def _trigger_runout(self, lane):
+        """Handle runout for lanes without dedicated load sensors."""
+        if self.check_runout(lane):
+            if lane.runout_lane is not None:
+                lane._perform_infinite_runout()
+            else:
+                lane._perform_pause_runout()
+        elif lane.status != "calibrating":
+            self.afc.function.afc_led(lane.led_not_ready, lane.led_index)
+            lane.status = AFCLaneState.NONE
+            lane.loaded_to_hub = False
+            self.afc.spool._clear_values(lane)
+            self.afc.function.afc_led(self.afc.led_not_ready, lane.led_index)
+        self.afc.save_vars()
+
+    def _on_oams_runout(self, fps_name, group, spool_idx):
+        """Callback from OAMSManager when a runout occurs."""
+        lane = self.lanes.get(group)
+        if lane is None:
+            return
+        eventtime = self.reactor.monotonic()
+        self._last_load_states[lane.name] = False
+        lane.load_callback(eventtime, False)
+        hub = getattr(lane, "hub_obj", None)
+        if hub is not None:
+            self._last_hub_states[hub.name] = False
+            hub.switch_pin_callback(eventtime, False)
+            if hasattr(hub, "fila"):
+                hub.fila.runout_helper.note_filament_present(eventtime, False)
+        self._trigger_runout(lane)
+
     def handle_ready(self):
         # Resolve OpenAMS object and start periodic polling
         self.oams = self.printer.lookup_object("oams " + self.oams_name, None)
+        self.oams_manager = self.printer.lookup_object("oams_manager", None)
+        if self.oams_manager is not None:
+            self.oams_manager.register_runout_callback(self._on_oams_runout)
         self.reactor.update_timer(self.timer, self.reactor.NOW)
 
     def _sync_event(self, eventtime):
+        if self.oams is None:
+            return eventtime + self.interval
+
+        # Request updated sensor values from the OpenAMS controller so
+        # new spools inserted into empty bays are detected.
         try:
-            if self.oams is None:
-                return eventtime + self.interval
+            self.oams.determine_current_spool()
+        except Exception:
+            pass
 
-            # Request updated sensor values from the OpenAMS controller so
-            # new spools inserted into empty bays are detected.
+        # Iterate through lanes belonging to this unit
+        for lane in list(self.lanes.values()):
+            idx = getattr(lane, "index", 0) - 1
+            if idx < 0:
+                continue
+
             try:
-                self.oams.determine_current_spool()
-            except Exception:
-                pass
-
-            # Iterate through lanes belonging to this unit
-            for lane in list(self.lanes.values()):
-                idx = getattr(lane, "index", 0) - 1
-                if idx < 0:
-                    continue
-
                 # OpenAMS exposes separate sensors for spool presence (prep)
-                # and filament loaded into the hub (load). Track changes for
-                # each independently so lane callbacks mirror physical state.
+                # and filament loaded into the hub (load). For AMS units the
+                # hub sensor only reports a value for the lane currently
+                # feeding the toolhead, so idle lanes must mirror the prep
+                # state in their load value. This keeps "locked" and "loaded"
+                # in sync for AMS lanes while still allowing active lanes to
+                # reflect true hub sensor readings.
                 prep_val = bool(self.oams.f1s_hes_value[idx])
+                hub_val = bool(self.oams.hub_hes_value[idx])
+
                 last_prep = self._last_prep_states.get(lane.name)
                 if prep_val != last_prep:
                     lane.prep_callback(eventtime, prep_val)
                     self._last_prep_states[lane.name] = prep_val
 
-                load_val = bool(self.oams.hub_hes_value[idx])
+                load_val = hub_val
+                if not lane.tool_loaded:
+                    load_val = prep_val
+
                 last_load = self._last_load_states.get(lane.name)
                 if load_val != last_load:
-                    lane.handle_load_runout(eventtime, load_val)
                     self._last_load_states[lane.name] = load_val
+                    if hasattr(lane, "load_debounce_button"):
+                        lane.handle_load_runout(eventtime, load_val)
+                    else:
+                        lane.load_callback(eventtime, load_val)
+                        # Only trigger runout when both the hub and prep
+                        # sensors report no filament. This avoids clearing
+                        # spool assignments during lane switches where the
+                        # hub sensor may briefly go low even though a spool
+                        # remains present.
+                        if not load_val and not prep_val:
+                            self._trigger_runout(lane)
+            except (IndexError, KeyError):
+                # Skip lanes that aren't reported by OpenAMS
+                continue
 
-                hub = getattr(lane, "hub_obj", None)
-                if hub is None:
-                    continue
+            hub = getattr(lane, "hub_obj", None)
+            if hub is None:
+                continue
 
-                last_hub = self._last_hub_states.get(hub.name)
-                if load_val != last_hub:
-                    hub.switch_pin_callback(eventtime, load_val)
-                    if hasattr(hub, "fila"):
-                        hub.fila.runout_helper.note_filament_present(
-                            eventtime, load_val)
-                    self._last_hub_states[hub.name] = load_val
-
-        except Exception:
-            # Avoid breaking the reactor loop if OpenAMS query fails
-            pass
+            last_hub = self._last_hub_states.get(hub.name)
+            if hub_val != last_hub:
+                hub.switch_pin_callback(eventtime, hub_val)
+                if hasattr(hub, "fila"):
+                    hub.fila.runout_helper.note_filament_present(
+                        eventtime, hub_val)
+                self._last_hub_states[hub.name] = hub_val
 
         return eventtime + self.interval
 


### PR DESCRIPTION
## Summary
- Allow OAMSManager to register an external runout callback
- AFC_AMS listens for OAMS runout events and forwards them to the corresponding lane
- Safeguard lane synchronization so OpenAMS indexing errors don't block subsequent lanes
- Handle runout for AMS lanes lacking a load sensor by updating hub state and invoking AFC lane failover logic
- Mirror AMS lane prep and load states when the lane isn't feeding the toolhead so locked/loaded remain in sync
- Fix hub state reporting by using dedicated hub sensor values instead of mirrored load state
- Avoid clearing spool assignments when switching AMS lanes by only triggering runout when both hub and prep sensors are inactive

## Testing
- `python -m py_compile klipper/klippy/extras/AFC_AMS.py klipper_openams/src/oams_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_68c32caaa3608326b62f65e640b6b9d2