### PR TITLE
Integrate OpenAMS runout callbacks with AFC

### DIFF
--- a/klipper/klippy/extras/AFC_AMS.py
+++ b/klipper/klippy/extras/AFC_AMS.py
@@ -93,6 +93,7 @@ class afcAMS(afcUnit):
         self.type = "AMS"
         self.oams_name = config.get("oams", "oams1")
         self.interval = config.getfloat("interval", SYNC_INTERVAL, above=0.0)
+        self.oams_manager = None
 
         self.reactor = self.printer.get_reactor()
         self.timer = self.reactor.register_timer(self._sync_event)
@@ -202,59 +203,112 @@ class afcAMS(afcUnit):
                 and cur_lane.status not in (AFCLaneState.EJECTING,
                                             AFCLaneState.CALIBRATING))
 
+    def _trigger_runout(self, lane):
+        """Handle runout for lanes without dedicated load sensors."""
+        if self.check_runout(lane):
+            if lane.runout_lane is not None:
+                lane._perform_infinite_runout()
+            else:
+                lane._perform_pause_runout()
+        elif lane.status != "calibrating":
+            self.afc.function.afc_led(lane.led_not_ready, lane.led_index)
+            lane.status = AFCLaneState.NONE
+            lane.loaded_to_hub = False
+            self.afc.spool._clear_values(lane)
+            self.afc.function.afc_led(self.afc.led_not_ready, lane.led_index)
+        self.afc.save_vars()
+
+    def _on_oams_runout(self, fps_name, group, spool_idx):
+        """Callback from OAMSManager when a runout occurs.
+
+        ``spool_idx`` is the index of the newly loaded spool or ``-1`` if the
+        manager could not load another spool and external runout handling is
+        required.
+        """
+        lane = self.lanes.get(group)
+        if lane is None:
+            return
+        eventtime = self.reactor.monotonic()
+        self._last_load_states[lane.name] = False
+        lane.load_callback(eventtime, False)
+        hub = getattr(lane, "hub_obj", None)
+        if hub is not None:
+            self._last_hub_states[hub.name] = False
+            hub.switch_pin_callback(eventtime, False)
+            if hasattr(hub, "fila"):
+                hub.fila.runout_helper.note_filament_present(eventtime, False)
+        if spool_idx < 0:
+            self._trigger_runout(lane)
+        else:
+            self.afc.spool._clear_values(lane)
+            self.afc.save_vars()
+
     def handle_ready(self):
         # Resolve OpenAMS object and start periodic polling
         self.oams = self.printer.lookup_object("oams " + self.oams_name, None)
+        self.oams_manager = self.printer.lookup_object("oams_manager", None)
+        if self.oams_manager is not None:
+            self.oams_manager.register_runout_callback(self._on_oams_runout)
         self.reactor.update_timer(self.timer, self.reactor.NOW)
 
     def _sync_event(self, eventtime):
+        if self.oams is None:
+            return eventtime + self.interval
+
+        # Request updated sensor values from the OpenAMS controller so
+        # new spools inserted into empty bays are detected.
         try:
-            if self.oams is None:
-                return eventtime + self.interval
+            self.oams.determine_current_spool()
+        except Exception:
+            pass
 
-            # Request updated sensor values from the OpenAMS controller so
-            # new spools inserted into empty bays are detected.
+        # Iterate through lanes belonging to this unit
+        for lane in list(self.lanes.values()):
+            idx = getattr(lane, "index", 0) - 1
+            if idx < 0:
+                continue
+
             try:
-                self.oams.determine_current_spool()
-            except Exception:
-                pass
-
-            # Iterate through lanes belonging to this unit
-            for lane in list(self.lanes.values()):
-                idx = getattr(lane, "index", 0) - 1
-                if idx < 0:
-                    continue
-
-                # OpenAMS exposes separate sensors for spool presence (prep)
-                # and filament loaded into the hub (load). Track changes for
-                # each independently so lane callbacks mirror physical state.
+                # OpenAMS exposes separate sensors for spool presence
+                # (f1s_hes_value) and the hub path (hub_hes_value). The
+                # spool sensor should drive both the prep and load states so
+                # that inserting filament reflects immediately in AFC, while
+                # the hub sensor is reported separately for informational
+                # purposes.
                 prep_val = bool(self.oams.f1s_hes_value[idx])
+                hub_val = bool(self.oams.hub_hes_value[idx])
+
                 last_prep = self._last_prep_states.get(lane.name)
                 if prep_val != last_prep:
                     lane.prep_callback(eventtime, prep_val)
                     self._last_prep_states[lane.name] = prep_val
 
-                load_val = bool(self.oams.hub_hes_value[idx])
+                load_val = prep_val
+
                 last_load = self._last_load_states.get(lane.name)
                 if load_val != last_load:
-                    lane.handle_load_runout(eventtime, load_val)
                     self._last_load_states[lane.name] = load_val
+                    if hasattr(lane, "load_debounce_button"):
+                        lane.handle_load_runout(eventtime, load_val)
+                    else:
+                        lane.load_callback(eventtime, load_val)
+            except (IndexError, KeyError):
+                # Skip lanes that aren't reported by OpenAMS
+                continue
 
-                hub = getattr(lane, "hub_obj", None)
-                if hub is None:
-                    continue
+            hub = getattr(lane, "hub_obj", None)
+            if hub is None:
+                continue
 
-                last_hub = self._last_hub_states.get(hub.name)
-                if load_val != last_hub:
-                    hub.switch_pin_callback(eventtime, load_val)
-                    if hasattr(hub, "fila"):
-                        hub.fila.runout_helper.note_filament_present(
-                            eventtime, load_val)
-                    self._last_hub_states[hub.name] = load_val
-
-        except Exception:
-            # Avoid breaking the reactor loop if OpenAMS query fails
-            pass
+            last_hub = self._last_hub_states.get(hub.name)
+            if hub_val != last_hub:
+                hub.switch_pin_callback(eventtime, hub_val)
+                if hasattr(hub, "fila"):
+                    hub.fila.runout_helper.note_filament_present(
+                        eventtime, hub_val)
+                self._last_hub_states[hub.name] = hub_val
+                if not hub_val and not load_val:
+                    self._trigger_runout(lane)
 
         return eventtime + self.interval
 

--- a/klipper_openams/src/oams_manager.py
+++ b/klipper_openams/src/oams_manager.py
@@ -81,14 +81,19 @@ class OAMSRunoutMonitor:
                 pass
             elif self.state == OAMSRunoutState.MONITORING:
                 #logging.info("OAMS: Monitoring runout, is_printing: %s, fps_state: %s, fps_state.current_group: %s, fps_state.current_spool_idx: %s, oams: %s" % (is_printing, fps_state.state_name, fps_state.current_group, fps_state.current_spool_idx, fps_state.current_oams))
-                if is_printing and \
-                fps_state.state_name == "LOADED" and \
-                fps_state.current_group is not None and \
-                fps_state.current_spool_idx is not None and \
-                not bool(self.oams[fps_state.current_oams].hub_hes_value[fps_state.current_spool_idx]):
-                    self.state = OAMSRunoutState.DETECTED
-                    logging.info(f"OAMS: Runout detected on FPS {self.fps_name}, pausing for {PAUSE_DISTANCE} mm before coasting the follower.")
-                    self.runout_position = fps.extruder.last_position
+                if (is_printing and
+                    fps_state.state_name == "LOADED" and
+                    fps_state.current_group is not None and
+                    fps_state.current_spool_idx is not None):
+                    oams = self.oams[fps_state.current_oams]
+                    spool_empty = not bool(oams.f1s_hes_value[fps_state.current_spool_idx])
+                    hub_empty = not bool(oams.hub_hes_value[fps_state.current_spool_idx])
+                    if spool_empty and hub_empty:
+                        self.state = OAMSRunoutState.DETECTED
+                        logging.info(
+                            f"OAMS: Runout detected on FPS {self.fps_name}, "
+                            f"pausing for {PAUSE_DISTANCE} mm before coasting the follower.")
+                        self.runout_position = fps.extruder.last_position
             
             elif self.state == OAMSRunoutState.DETECTED:
                 traveled_distance = fps.extruder.last_position - self.runout_position
@@ -243,9 +248,12 @@ class OAMSManager:
         # Monitoring and control
         self.monitor_timers: List[Any] = []  # Active monitoring timers
         self.ready: bool = False  # System initialization complete
-        
+
         # Configuration parameters
         self.reload_before_toolhead_distance: float = config.getfloat("reload_before_toolhead_distance", 0.0)
+
+        # External integration
+        self.runout_callback: Optional[Callable[[str, str, int], None]] = None
         
         # Initialize hardware collections
         self._initialize_oams()
@@ -255,7 +263,17 @@ class OAMSManager:
         self.printer.register_event_handler("klippy:ready", self.handle_ready)
         self.printer.add_object("oams_manager", self)
         self.register_commands()
-        
+
+    def register_runout_callback(self, callback: Callable[[str, str, int], None]) -> None:
+        """Register a callback for runout events.
+
+        After the manager attempts to reload from the filament group the
+        callback is invoked with ``fps_name``, ``group`` and ``spool_idx``.
+        ``spool_idx`` is the index of the newly loaded spool or ``-1`` if no
+        spool was available so external handling is required.
+        """
+        self.runout_callback = callback
+
     def get_status(self, eventtime: float) -> Dict[str, Dict[str, Any]]:
         """
         Return current status of all FPS units for monitoring.
@@ -616,12 +634,13 @@ class OAMSManager:
             self.monitor_timers.append(reactor.register_timer(self._monitor_unload_speed_for_fps(fps_name), reactor.NOW))
             self.monitor_timers.append(reactor.register_timer(self._monitor_load_speed_for_fps(fps_name), reactor.NOW))
             
-            def _reload_callback():
+            def _reload_callback(fps_name=fps_name, fps_state=fps_state):
                 for (oam, bay_index) in self.filament_groups[fps_state.current_group].bays:
                     if oam.is_bay_ready(bay_index):
                         success, message = oam.load_spool(bay_index)
                         if success:
-                            logging.info(f"OAMS: Successfully loaded spool in bay {bay_index} of OAM {oam.name}")
+                            logging.info(
+                                f"OAMS: Successfully loaded spool in bay {bay_index} of OAM {oam.name}")
                             fps_state.state_name = "LOADED"
                             fps_state.since = self.reactor.monotonic()
                             fps_state.current_spool_idx = bay_index
@@ -629,14 +648,23 @@ class OAMSManager:
                             fps_state.reset_runout_positions()
                             self.runout_monitor.reset()
                             self.runout_monitor.start()
+                            if self.runout_callback is not None:
+                                self.runout_callback(fps_name, fps_state.current_group, bay_index)
                             return
                         else:
                             logging.error(f"OAMS: Failed to load spool: {message}")
                             break
-                self._pause_printer_message("No spool available for group %s" % fps_state.current_group)
+                self._pause_printer_message(
+                    "No spool available for group %s" % fps_state.current_group)
                 self.runout_monitor.paused()
+                if self.runout_callback is not None:
+                    self.runout_callback(
+                        fps_name,
+                        fps_state.current_group,
+                        -1,
+                    )
                 return
-            
+
             self.runout_monitor = OAMSRunoutMonitor(self.printer, fps_name, self.fpss[fps_name], fps_state, self.oams, _reload_callback, reload_before_toolhead_distance=self.reload_before_toolhead_distance)
             self.monitor_timers.append(self.runout_monitor.timer)
             self.runout_monitor.start()


### PR DESCRIPTION
## Summary
- Notify AFC after OpenAMS attempts internal spool reloads, passing the new spool index or `-1` on failure
- Clear AFC spool assignments on OpenAMS runout and only trigger AFC lane failover when no replacement spool is available

## Testing
- `python -m py_compile klipper/klippy/extras/AFC_AMS.py klipper_openams/src/oams_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_68c32caaa3608326b62f65e640b6b9d2