### PR TITLE
Integrate OpenAMS runout callbacks with AFC

### DIFF
--- a/AFC-Klipper-Add-On/extras/AFC_lane.py
+++ b/AFC-Klipper-Add-On/extras/AFC_lane.py
@@ -961,7 +961,9 @@ class AFCLane:
             self.afc.error.pause_resume.send_pause_command()
             self.afc.save_pos()
             self.afc.error.AFC_error(msg)
-        # No else: do not trigger infinite runout or pause runout here
+        else:
+            if hasattr(self.unit_obj, "_trigger_runout"):
+                self.unit_obj._trigger_runout(self)
 
     def handle_hub_runout(self, sensor=None):
         """

--- a/klipper/klippy/extras/AFC_AMS.py
+++ b/klipper/klippy/extras/AFC_AMS.py
@@ -93,6 +93,8 @@ class afcAMS(afcUnit):
         self.type = "AMS"
         self.oams_name = config.get("oams", "oams1")
         self.interval = config.getfloat("interval", SYNC_INTERVAL, above=0.0)
+        self.oams_manager = None
+        self._pending_oams = {}
 
         self.reactor = self.printer.get_reactor()
         self.timer = self.reactor.register_timer(self._sync_event)
@@ -202,59 +204,126 @@ class afcAMS(afcUnit):
                 and cur_lane.status not in (AFCLaneState.EJECTING,
                                             AFCLaneState.CALIBRATING))
 
+    def _trigger_runout(self, lane):
+        """Handle runout for lanes without dedicated load sensors."""
+        if not self.check_runout(lane):
+            if lane.status != "calibrating":
+                self.afc.function.afc_led(lane.led_not_ready, lane.led_index)
+                lane.status = AFCLaneState.NONE
+                lane.loaded_to_hub = False
+                self.afc.spool._clear_values(lane)
+                self.afc.function.afc_led(self.afc.led_not_ready, lane.led_index)
+            self.afc.save_vars()
+            return
+
+        pending = self._pending_oams.pop(lane.name, None)
+        loaded_via_oams = False
+        if pending and self.oams_manager is not None:
+            fps_name, ro_lane_name, idx = pending
+            if self.oams_manager.load_spool_for_lane(
+                    fps_name, ro_lane_name, self.oams_name, idx):
+                loaded_via_oams = True
+                cur_ext = self.afc.function.get_current_extruder()
+                if cur_ext in self.afc.tools:
+                    self.afc.tools[cur_ext].lane_loaded = ro_lane_name
+                    self.afc.current = ro_lane_name
+                ro_lane = self.afc.lanes.get(ro_lane_name)
+                if ro_lane is not None:
+                    ro_lane.unit_obj.lane_loaded(ro_lane)
+
+        if loaded_via_oams:
+            self.afc.save_vars()
+            return
+
+        if lane.runout_lane is not None:
+            lane._perform_infinite_runout()
+        else:
+            lane._perform_pause_runout()
+        self.afc.save_vars()
+
+    def _on_oams_runout(self, fps_name, group, spool_idx):
+        """Callback from OAMSManager when a runout occurs.
+
+        ``spool_idx`` is the index of the newly loaded spool or ``-1`` if the
+        manager could not load another spool and external runout handling is
+        required.
+        """
+        lane = self.lanes.get(group)
+        if lane is None:
+            return
+        if spool_idx < 0:
+            ro_lane_name = lane.runout_lane
+            if ro_lane_name:
+                ro_lane = self.afc.lanes.get(ro_lane_name)
+                idx = getattr(ro_lane, "index", 0) - 1 if ro_lane else -1
+                if (ro_lane is not None and idx >= 0 and
+                    getattr(ro_lane, "unit_obj", None) is getattr(lane, "unit_obj", None)):
+                    self._pending_oams[lane.name] = (fps_name, ro_lane.name, idx)
+
     def handle_ready(self):
         # Resolve OpenAMS object and start periodic polling
         self.oams = self.printer.lookup_object("oams " + self.oams_name, None)
+        self.oams_manager = self.printer.lookup_object("oams_manager", None)
+        if self.oams_manager is not None:
+            self.oams_manager.register_runout_callback(self._on_oams_runout)
         self.reactor.update_timer(self.timer, self.reactor.NOW)
 
     def _sync_event(self, eventtime):
+        if self.oams is None:
+            return eventtime + self.interval
+
+        # Request updated sensor values from the OpenAMS controller so
+        # new spools inserted into empty bays are detected.
         try:
-            if self.oams is None:
-                return eventtime + self.interval
+            self.oams.determine_current_spool()
+        except Exception:
+            pass
 
-            # Request updated sensor values from the OpenAMS controller so
-            # new spools inserted into empty bays are detected.
+        # Iterate through lanes belonging to this unit
+        for lane in list(self.lanes.values()):
+            idx = getattr(lane, "index", 0) - 1
+            if idx < 0:
+                continue
+
             try:
-                self.oams.determine_current_spool()
-            except Exception:
-                pass
-
-            # Iterate through lanes belonging to this unit
-            for lane in list(self.lanes.values()):
-                idx = getattr(lane, "index", 0) - 1
-                if idx < 0:
-                    continue
-
-                # OpenAMS exposes separate sensors for spool presence (prep)
-                # and filament loaded into the hub (load). Track changes for
-                # each independently so lane callbacks mirror physical state.
+                # OpenAMS exposes separate sensors for spool presence
+                # (f1s_hes_value) and the hub path (hub_hes_value). The
+                # spool sensor should drive both the prep and load states so
+                # that inserting filament reflects immediately in AFC, while
+                # the hub sensor is reported separately for informational
+                # purposes.
                 prep_val = bool(self.oams.f1s_hes_value[idx])
+                hub_val = bool(self.oams.hub_hes_value[idx])
+
                 last_prep = self._last_prep_states.get(lane.name)
                 if prep_val != last_prep:
                     lane.prep_callback(eventtime, prep_val)
                     self._last_prep_states[lane.name] = prep_val
 
-                load_val = bool(self.oams.hub_hes_value[idx])
+                load_val = prep_val
+
                 last_load = self._last_load_states.get(lane.name)
                 if load_val != last_load:
-                    lane.handle_load_runout(eventtime, load_val)
                     self._last_load_states[lane.name] = load_val
+                    if hasattr(lane, "load_debounce_button"):
+                        lane.handle_load_runout(eventtime, load_val)
+                    else:
+                        lane.load_callback(eventtime, load_val)
+            except (IndexError, KeyError):
+                # Skip lanes that aren't reported by OpenAMS
+                continue
 
-                hub = getattr(lane, "hub_obj", None)
-                if hub is None:
-                    continue
+            hub = getattr(lane, "hub_obj", None)
+            if hub is None:
+                continue
 
-                last_hub = self._last_hub_states.get(hub.name)
-                if load_val != last_hub:
-                    hub.switch_pin_callback(eventtime, load_val)
-                    if hasattr(hub, "fila"):
-                        hub.fila.runout_helper.note_filament_present(
-                            eventtime, load_val)
-                    self._last_hub_states[hub.name] = load_val
-
-        except Exception:
-            # Avoid breaking the reactor loop if OpenAMS query fails
-            pass
+            last_hub = self._last_hub_states.get(hub.name)
+            if hub_val != last_hub:
+                hub.switch_pin_callback(eventtime, hub_val)
+                if hasattr(hub, "fila"):
+                    hub.fila.runout_helper.note_filament_present(
+                        eventtime, hub_val)
+                self._last_hub_states[hub.name] = hub_val
 
         return eventtime + self.interval
 


### PR DESCRIPTION
## Summary
- Track pending OpenAMS runouts and defer infinite-spool lane switching until the toolhead sensor empties
- Invoke AFC runout logic from the toolhead sensor handler so AMS lanes fail over only after filament clears the toolhead
- Prevent OpenAMS from pausing the printer when a filament group lacks a fallback spool, allowing AFC to perform lane switching
- Wait for OpenAMS to reload a fallback spool and update the active lane before invoking AFC's infinite-spool fallback logic

## Testing
- `python -m py_compile klipper/klippy/extras/AFC_AMS.py klipper_openams/src/oams_manager.py AFC-Klipper-Add-On/extras/AFC_lane.py`


------
https://chatgpt.com/codex/tasks/task_e_68c32caaa3608326b62f65e640b6b9d2