### PR TITLE
Expose runout callback for AFC integration

### DIFF
--- a/klipper/klippy/extras/AFC_AMS.py
+++ b/klipper/klippy/extras/AFC_AMS.py
@@ -98,6 +98,8 @@ class afcAMS(afcUnit):
         self.timer = self.reactor.register_timer(self._sync_event)
         self.printer.register_event_handler("klippy:ready", self.handle_ready)
 
+        self.oams_manager = None
+
         # Track last sensor states so callbacks only trigger on changes
         self._last_prep_states = {}
         self._last_load_states = {}
@@ -203,38 +205,85 @@ class afcAMS(afcUnit):
                                             AFCLaneState.CALIBRATING))
 
     def handle_ready(self):
-        # Resolve OpenAMS object and start periodic polling
+        # Resolve OpenAMS objects and register for runout callbacks
         self.oams = self.printer.lookup_object("oams " + self.oams_name, None)
+        self.oams_manager = self.printer.lookup_object("oams_manager", None)
+        if self.oams_manager is not None:
+            self.oams_manager.register_runout_callback(self._on_oams_runout)
         self.reactor.update_timer(self.timer, self.reactor.NOW)
 
+    def _on_oams_runout(self, fps_name, spool_idx):
+        """Forward OpenAMS runout events to the active lane.
+
+        When a new spool is loaded on the same FPS, switch to its lane by
+        issuing the corresponding ``T#`` command. If no spool could be loaded,
+        invoke AFC's standard runout handling for the active lane.
+        """
+        lane_name = self.afc.function.get_current_lane()
+        lane = self.lanes.get(lane_name)
+        if lane is None:
+            return
+
+        if spool_idx >= 0 and self.oams_manager is not None:
+            # Determine which OAMS and bay were loaded and compute the global
+            # lane number so the printer switches tools accordingly.
+            fps_state = self.oams_manager.current_state.fps_state.get(fps_name)
+            if fps_state is None:
+                return
+            oams_obj = self.oams_manager.oams.get(fps_state.current_oams)
+            if oams_obj is None:
+                return
+            tool = (oams_obj.oams_idx - 1) * 4 + spool_idx + 1
+            gcode = self.printer.lookup_object("gcode")
+            gcode.run_script_from_command(f"T{tool}")
+            return
+
+        eventtime = self.reactor.monotonic()
+        lane.handle_load_runout(eventtime, False)
+
     def _sync_event(self, eventtime):
+        if self.oams is None:
+            return eventtime + self.interval
+
+        # Request updated sensor values from the OpenAMS controller so
+        # new spools inserted into empty bays are detected.
         try:
-            if self.oams is None:
-                return eventtime + self.interval
+            self.oams.determine_current_spool()
+        except Exception:
+            pass
 
-            # Request updated sensor values from the OpenAMS controller so
-            # new spools inserted into empty bays are detected.
+        # Iterate through lanes belonging to this unit
+        sensor_len = min(len(self.oams.f1s_hes_value), len(self.oams.hub_hes_value))
+        if sensor_len == 0:
+            return eventtime + self.interval
+
+        for lane in list(self.lanes.values()):
             try:
-                self.oams.determine_current_spool()
-            except Exception:
-                pass
-
-            # Iterate through lanes belonging to this unit
-            for lane in list(self.lanes.values()):
                 idx = getattr(lane, "index", 0) - 1
                 if idx < 0:
                     continue
+                # Each AMS unit only reports four bays, but AFC lane
+                # indices may be global across multiple units. Wrap the
+                # lane index so the correct sensor slot is used.
+                idx %= sensor_len
 
                 # OpenAMS exposes separate sensors for spool presence (prep)
-                # and filament loaded into the hub (load). Track changes for
-                # each independently so lane callbacks mirror physical state.
+                # and filament at the hub. Idle AMS lanes should report their
+                # load state based on spool presence so "locked" and
+                # "loaded" remain in sync, while the active lane reflects the
+                # true hub sensor. Track each of these values independently.
                 prep_val = bool(self.oams.f1s_hes_value[idx])
                 last_prep = self._last_prep_states.get(lane.name)
                 if prep_val != last_prep:
                     lane.prep_callback(eventtime, prep_val)
                     self._last_prep_states[lane.name] = prep_val
 
-                load_val = bool(self.oams.hub_hes_value[idx])
+                hub_val = bool(self.oams.hub_hes_value[idx])
+                if lane.name == self.afc.function.get_current_lane():
+                    load_val = hub_val
+                else:
+                    load_val = prep_val
+
                 last_load = self._last_load_states.get(lane.name)
                 if load_val != last_load:
                     lane.handle_load_runout(eventtime, load_val)
@@ -244,17 +293,21 @@ class afcAMS(afcUnit):
                 if hub is None:
                     continue
 
+                # Idle AMS lanes don't feed filament through the hub, so their
+                # load state mirrors spool presence. Use that derived load
+                # state when updating the hub sensor so "locked" and "loaded"
+                # stay in sync for non‑active lanes.
+                hub_state = load_val
                 last_hub = self._last_hub_states.get(hub.name)
-                if load_val != last_hub:
-                    hub.switch_pin_callback(eventtime, load_val)
+                if hub_state != last_hub:
+                    hub.switch_pin_callback(eventtime, hub_state)
                     if hasattr(hub, "fila"):
                         hub.fila.runout_helper.note_filament_present(
-                            eventtime, load_val)
-                    self._last_hub_states[hub.name] = load_val
-
-        except Exception:
-            # Avoid breaking the reactor loop if OpenAMS query fails
-            pass
+                            eventtime, hub_state)
+                    self._last_hub_states[hub.name] = hub_state
+            except Exception:
+                # Skip lanes that can't be queried but continue updating others
+                continue
 
         return eventtime + self.interval
 

--- a/klipper_openams/src/oams_manager.py
+++ b/klipper_openams/src/oams_manager.py
@@ -12,6 +12,7 @@ from typing import Optional, Tuple, Dict, List, Any, Callable
 
 # Configuration constants
 PAUSE_DISTANCE = 60  # mm to pause before coasting follower
+EXTRA_COAST_DISTANCE = 30  # additional mm to coast before loading next spool
 ENCODER_SAMPLES = 2  # Number of encoder samples to collect
 MIN_ENCODER_DIFF = 1  # Minimum encoder difference to consider movement
 FILAMENT_PATH_LENGTH_FACTOR = 1.14  # Factor for calculating filament path traversal
@@ -100,7 +101,10 @@ class OAMSRunoutMonitor:
                     
             elif self.state == OAMSRunoutState.COASTING:
                 traveled_distance_after_bldc_clear = fps.extruder.last_position - self.bldc_clear_position
-                if traveled_distance_after_bldc_clear + self.reload_before_toolhead_distance > self.oams[fps_state.current_oams].filament_path_length / FILAMENT_PATH_LENGTH_FACTOR:
+                if traveled_distance_after_bldc_clear + self.reload_before_toolhead_distance > (
+                    self.oams[fps_state.current_oams].filament_path_length / FILAMENT_PATH_LENGTH_FACTOR
+                    + EXTRA_COAST_DISTANCE
+                ):
                     logging.info("OAMS: Loading next spool in the filament group.")
                     self.state = OAMSRunoutState.RELOADING
                     self.reload_callback()
@@ -245,16 +249,34 @@ class OAMSManager:
         self.ready: bool = False  # System initialization complete
         
         # Configuration parameters
-        self.reload_before_toolhead_distance: float = config.getfloat("reload_before_toolhead_distance", 0.0)
-        
+        self.reload_before_toolhead_distance: float = config.getfloat(
+            "reload_before_toolhead_distance", 0.0
+        )
+
+        # External runout callback (fps_name, new_spool_idx)
+        self._runout_callback: Optional[Callable[[str, int], None]] = None
+
         # Initialize hardware collections
         self._initialize_oams()
         self._initialize_filament_groups()
-        
+
         # Register with printer and setup event handlers
         self.printer.register_event_handler("klippy:ready", self.handle_ready)
         self.printer.add_object("oams_manager", self)
         self.register_commands()
+
+    def register_runout_callback(self, callback: Callable[[str, int], None]) -> None:
+        """Register a callback invoked after a runout reload attempt."""
+        self._runout_callback = callback
+
+    def _notify_runout(self, fps_name: str, spool_idx: int) -> None:
+        cb = self._runout_callback
+        if cb is None:
+            return
+        try:
+            cb(fps_name, spool_idx)
+        except Exception:
+            logging.exception("OAMS: runout callback failed")
         
     def get_status(self, eventtime: float) -> Dict[str, Dict[str, Any]]:
         """
@@ -629,10 +651,12 @@ class OAMSManager:
                             fps_state.reset_runout_positions()
                             self.runout_monitor.reset()
                             self.runout_monitor.start()
+                            self._notify_runout(fps_name, bay_index)
                             return
                         else:
                             logging.error(f"OAMS: Failed to load spool: {message}")
                             break
+                self._notify_runout(fps_name, -1)
                 self._pause_printer_message("No spool available for group %s" % fps_state.current_group)
                 self.runout_monitor.paused()
                 return

--- a/printer_data/config/oamsc.cfg
+++ b/printer_data/config/oamsc.cfg
@@ -289,4 +289,9 @@ extruder: extruder5
 
 [oams_manager]
 
+# Delay OpenAMS spool reloads until the toolhead has moved 100mm past
+# the hub sensor. Negative values add extra coasting before a reload is
+# attempted.
+reload_before_toolhead_distance: -100
+
 [include oams_macros.cfg]


### PR DESCRIPTION
## Summary
- allow external modules to register for OpenAMS runout events
- afcAMS hooks into that callback and forwards failed reloads to the current lane
- after OpenAMS reloads a spool on the same FPS, automatically issue the corresponding T# command to switch lanes
- runout monitor still coasts an extra 30 mm before loading the next spool
- fix AMS lane synchronization so all bays update independently
- track AMS hub sensors separately from spool presence so idle lanes keep loaded state
- wrap lane indexes per AMS so hub sensors report correctly across units
- mirror hub sensor updates to lane load state so non‑active AMS lanes stay in sync
- expose `reload_before_toolhead_distance` in config to delay spool reloads

## Testing
- `python -m py_compile klipper/klippy/extras/AFC_AMS.py klipper_openams/src/oams_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_68c32caaa3608326b62f65e640b6b9d2