### PR TITLE
Call filament group after infinite spool reload

### DIFF
--- a/klipper_openams/src/oams_manager.py
+++ b/klipper_openams/src/oams_manager.py
@@ -681,6 +681,8 @@ class OAMSManager:
                             fps_state.reset_runout_positions()
                             self.runout_monitor.reset()
                             self.runout_monitor.start()
+                            gcode = self.printer.lookup_object("gcode")
+                            gcode.run_script(fps_state.current_group)
                             if self.runout_callback is not None:
                                 self.runout_callback(fps_name, fps_state.current_group, bay_index)
                             return


### PR DESCRIPTION
## Summary
- ensure runout reloads invoke filament-group gcode

## Testing
- `python -m py_compile klipper_openams/src/oams_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_68c3be9fbf2c83269a80f67d0d8b8fd2