### PR TITLE
Add bed heat soak macro

### DIFF
--- a/printer_data/config/dynamic.cfg
+++ b/printer_data/config/dynamic.cfg
@@ -1,23 +1,20 @@
-# [gcode_macro HEAT_SOAK_BED]
-# description: "Heat soak the bed at 65C for 5 minutes"
-# gcode:
-#   {% set BED_TEMP = params.BED_TEMP|default(45)|float %}
-#   M140 S{BED_TEMP}                     ; Set bed temperature to 65C (no wait)
-#   M190 S{BED_TEMP}                     ; Wait for bed to reach 65C
-#   M117 Heat soaking bed...     ; Display message on printer screen
-#   G4 P250000                      ; Wait for 300 seconds (5 minutes)
-#   M117 Heat soak complete      ; Update display after soak
+[gcode_macro HEAT_SOAK_BED]
+description: "Heat soak the bed at 65C for 5 minutes"
+gcode:
+  {% set BED_TEMP = params.BED_TEMP|default(65)|float %}
+  M140 S{BED_TEMP}                     ; Set bed temperature to 65C (no wait)
+  M190 S{BED_TEMP}                     ; Wait for bed to reach 65C
+  M117 Heat soaking bed...             ; Display message on printer screen
+  G4 P300000                           ; Wait for 300 seconds (5 minutes)
+  M117 Heat soak complete              ; Update display after soak
 
-# [gcode_macro WAIT_HEAT_SOAK]
-# variable_threshold_temp: 35 #in °C
-
-# gcode:
-
-#  {% if printer.heater_bed.temperature <= threshold_temp %}
-#  HEAT_SOAK_BED
- 
-#  {% else %}
-#  #RESPOND MSG="skipping heat soak... ({printer.heater_bed.temperature} > {threshold_temp}) "
-
-#  {% endif %}
+[gcode_macro WAIT_HEAT_SOAK]
+variable_threshold_temp: 35 # in °C
+gcode:
+  {% set threshold = threshold_temp|float %}
+  {% if printer.heater_bed.temperature < threshold %}
+    HEAT_SOAK_BED
+  {% else %}
+    RESPOND MSG="skipping heat soak... ({printer.heater_bed.temperature} > {threshold}) "
+  {% endif %}
 


### PR DESCRIPTION
## Summary
- add HEAT_SOAK_BED macro for warming and soaking the build surface
- add WAIT_HEAT_SOAK macro to call heat soak only when bed temperature is below a threshold
- cast heat soak threshold to a float before comparing with current bed temperature

## Testing
- `pytest` (no tests ran)


------
https://chatgpt.com/codex/tasks/task_e_68c472a5b38c8326b35c4a8a8c4d157e