### PR TITLE
Add bed heat soak macro

### DIFF
--- a/printer_data/config/dynamic.cfg
+++ b/printer_data/config/dynamic.cfg
@@ -1,23 +1,39 @@
-# [gcode_macro HEAT_SOAK_BED]
-# description: "Heat soak the bed at 65C for 5 minutes"
-# gcode:
-#   {% set BED_TEMP = params.BED_TEMP|default(45)|float %}
-#   M140 S{BED_TEMP}                     ; Set bed temperature to 65C (no wait)
-#   M190 S{BED_TEMP}                     ; Wait for bed to reach 65C
-#   M117 Heat soaking bed...     ; Display message on printer screen
-#   G4 P250000                      ; Wait for 300 seconds (5 minutes)
-#   M117 Heat soak complete      ; Update display after soak
+[gcode_macro HEAT_SOAK_BED]
+description: "Heat soak the bed at 65C for 5 minutes"
+gcode:
+  {% set BED_TEMP = params.BED_TEMP|default(65)|float %}
+  {% set SOAK_TIME = params.SOAK_TIME|default(300)|int %}
+  M140 S{BED_TEMP}                     ; Set bed temperature (no wait)
+  M190 S{BED_TEMP}                     ; Wait for bed to reach target
+  RESPOND TYPE=command MSG="action:prompt_begin Heat soaking bed for {SOAK_TIME // 60}m"
+  RESPOND TYPE=command MSG="action:prompt_button Skip SKIP_HEAT_SOAK"
+  RESPOND TYPE=command MSG="action:prompt_show"
+  UPDATE_DELAYED_GCODE ID=END_HEAT_SOAK DURATION={SOAK_TIME}
+  PAUSE
 
-# [gcode_macro WAIT_HEAT_SOAK]
-# variable_threshold_temp: 35 #in °C
+[delayed_gcode END_HEAT_SOAK]
+gcode:
+  RESPOND TYPE=command MSG="action:prompt_end"
+  RESUME
+  RESPOND MSG="Heat soak complete"
 
-# gcode:
+[gcode_macro SKIP_HEAT_SOAK]
+gcode:
+  RESPOND TYPE=command MSG="action:prompt_end"
+  UPDATE_DELAYED_GCODE ID=END_HEAT_SOAK DURATION=0
+  {% if printer.print_stats.state != 'printing' %}
+    M140 S0
+  {% endif %}
+  RESUME
+  RESPOND MSG="Heat soak skipped"
 
-#  {% if printer.heater_bed.temperature <= threshold_temp %}
-#  HEAT_SOAK_BED
- 
-#  {% else %}
-#  #RESPOND MSG="skipping heat soak... ({printer.heater_bed.temperature} > {threshold_temp}) "
-
-#  {% endif %}
+[gcode_macro WAIT_HEAT_SOAK]
+variable_threshold_temp: 35 # in °C
+gcode:
+  {% set threshold = threshold_temp|float %}
+  {% if printer.heater_bed.temperature < threshold %}
+    HEAT_SOAK_BED
+  {% else %}
+    RESPOND MSG="skipping heat soak... ({printer.heater_bed.temperature} > {threshold}) "
+  {% endif %}
 


### PR DESCRIPTION
## Summary
- add skippable HEAT_SOAK_BED macro that pauses with a prompt allowing the user to skip the soak
- add WAIT_HEAT_SOAK macro to call heat soak only when bed temperature is below a threshold
- cast heat soak threshold to a float before comparing with current bed temperature
- ensure prompt displays correctly and closes after soak or skip

## Testing
- `pytest` (no tests ran)


------
https://chatgpt.com/codex/tasks/task_e_68c472a5b38c8326b35c4a8a8c4d157e