### PR TITLE
Add bed heat soak macro

### DIFF
--- a/printer_data/config/dynamic.cfg
+++ b/printer_data/config/dynamic.cfg
@@ -1,23 +1,47 @@
-# [gcode_macro HEAT_SOAK_BED]
-# description: "Heat soak the bed at 65C for 5 minutes"
-# gcode:
-#   {% set BED_TEMP = params.BED_TEMP|default(45)|float %}
-#   M140 S{BED_TEMP}                     ; Set bed temperature to 65C (no wait)
-#   M190 S{BED_TEMP}                     ; Wait for bed to reach 65C
-#   M117 Heat soaking bed...     ; Display message on printer screen
-#   G4 P250000                      ; Wait for 300 seconds (5 minutes)
-#   M117 Heat soak complete      ; Update display after soak
+[gcode_macro HEAT_SOAK_BED]
+description: "Heat soak the bed at 65C for 5 minutes"
+variable_soak_active: 0
+gcode:
+  {% set BED_TEMP = params.BED_TEMP|default(65)|float %}
+  {% set SOAK_TIME = params.SOAK_TIME|default(300)|int %}
+  SET_GCODE_VARIABLE MACRO=HEAT_SOAK_BED VARIABLE=soak_active VALUE=1
+  M140 S{BED_TEMP}                     ; Set bed temperature (no wait)
+  M190 S{BED_TEMP}                     ; Wait for bed to reach target
+  RESPOND TYPE=command MSG="action:prompt_begin Heat soaking bed for {SOAK_TIME // 60}m"
+  RESPOND TYPE=command MSG="action:prompt_button Skip SKIP_HEAT_SOAK"
+  RESPOND TYPE=command MSG="action:prompt_show"
+  UPDATE_DELAYED_GCODE ID=END_HEAT_SOAK DURATION={SOAK_TIME}
+  PAUSE
 
-# [gcode_macro WAIT_HEAT_SOAK]
-# variable_threshold_temp: 35 #in °C
+[delayed_gcode END_HEAT_SOAK]
+initial_duration: 1
+gcode:
+  UPDATE_DELAYED_GCODE ID=END_HEAT_SOAK DURATION=0
+  {% if printer["gcode_macro HEAT_SOAK_BED"].soak_active|int %}
+    RESPOND TYPE=command MSG="action:prompt_end"
+    SET_GCODE_VARIABLE MACRO=HEAT_SOAK_BED VARIABLE=soak_active VALUE=0
+    RESUME
+    RESPOND MSG="Heat soak complete"
+  {% endif %}
 
-# gcode:
+[gcode_macro SKIP_HEAT_SOAK]
+gcode:
+  RESPOND TYPE=command MSG="action:prompt_end"
+  UPDATE_DELAYED_GCODE ID=END_HEAT_SOAK DURATION=0
+  {% if printer.print_stats.state != 'printing' %}
+    M140 S0
+  {% endif %}
+  SET_GCODE_VARIABLE MACRO=HEAT_SOAK_BED VARIABLE=soak_active VALUE=0
+  RESUME
+  RESPOND MSG="Heat soak skipped"
 
-#  {% if printer.heater_bed.temperature <= threshold_temp %}
-#  HEAT_SOAK_BED
- 
-#  {% else %}
-#  #RESPOND MSG="skipping heat soak... ({printer.heater_bed.temperature} > {threshold_temp}) "
-
-#  {% endif %}
+[gcode_macro WAIT_HEAT_SOAK]
+variable_threshold_temp: 35 # in °C
+gcode:
+  {% set threshold = threshold_temp|float %}
+  {% if printer.heater_bed.temperature < threshold %}
+    HEAT_SOAK_BED
+  {% else %}
+    RESPOND MSG="skipping heat soak... ({printer.heater_bed.temperature} > {threshold}) "
+  {% endif %}
 


### PR DESCRIPTION
## Summary
- add skippable HEAT_SOAK_BED macro that pauses with a prompt allowing the user to skip the soak
- add WAIT_HEAT_SOAK macro to call heat soak only when bed temperature is below a threshold
- cast heat soak threshold to a float before comparing with current bed temperature
- ensure prompt displays correctly and closes after soak or skip
- initialize END_HEAT_SOAK delayed macro with initial_duration so UPDATE_DELAYED_GCODE works without errors
- track soak state to guard against unexpected timer callbacks

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c472a5b38c8326b35c4a8a8c4d157e