### PR TITLE
Improve runout monitor for infinite spool

### DIFF
--- a/klipper_openams/src/oams_manager.py
+++ b/klipper_openams/src/oams_manager.py
@@ -65,7 +65,6 @@ class OAMSRunoutMonitor:
         # State tracking
         self.state = OAMSRunoutState.STOPPED
         self.runout_position: Optional[float] = None
-        self.bldc_clear_position: Optional[float] = None
         
         # Configuration
         self.reload_before_toolhead_distance = reload_before_toolhead_distance
@@ -100,12 +99,12 @@ class OAMSRunoutMonitor:
                 if traveled_distance >= PAUSE_DISTANCE:
                     logging.info("OAMS: Pause complete, coasting the follower.")
                     self.oams[fps_state.current_oams].set_oams_follower(0, 1)
-                    self.bldc_clear_position = fps.extruder.last_position
                     self.state = OAMSRunoutState.COASTING
-                    
+
             elif self.state == OAMSRunoutState.COASTING:
-                traveled_distance_after_bldc_clear = fps.extruder.last_position - self.bldc_clear_position
-                if traveled_distance_after_bldc_clear + self.reload_before_toolhead_distance > self.oams[fps_state.current_oams].filament_path_length / FILAMENT_PATH_LENGTH_FACTOR:
+                total_distance = fps.extruder.last_position - self.runout_position
+                if total_distance + self.reload_before_toolhead_distance > \
+                        self.oams[fps_state.current_oams].filament_path_length / FILAMENT_PATH_LENGTH_FACTOR:
                     logging.info("OAMS: Loading next spool in the filament group.")
                     self.state = OAMSRunoutState.RELOADING
                     self.reload_callback()
@@ -126,7 +125,6 @@ class OAMSRunoutMonitor:
         """Set state to reloading and reset positions."""
         self.state = OAMSRunoutState.RELOADING
         self.runout_position = None
-        self.runout_after_position = None
         
     def paused(self) -> None:
         """Pause the monitor due to error or manual intervention."""
@@ -136,7 +134,6 @@ class OAMSRunoutMonitor:
         """Reset monitor to stopped state and clean up."""
         self.state = OAMSRunoutState.STOPPED
         self.runout_position = None
-        self.runout_after_position = None
         if self.timer is not None:
             self.printer.get_reactor().unregister_timer(self.timer)
             self.timer = None


### PR DESCRIPTION
## Summary
- Track total distance from runout before reloading spool
- Reload only after follower has coasted past hub to toolhead

## Testing
- `python -m py_compile klipper_openams/src/oams_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_68c5bdccee808326bf664b15e1deb9c6