### PR TITLE
Handle AMS runouts with shared FPS in OpenAMS

### DIFF
--- a/klipper/klippy/extras/AFC_AMS.py
+++ b/klipper/klippy/extras/AFC_AMS.py
@@ -197,7 +197,20 @@ class afcAMS(afcUnit):
         return succeeded
 
     def check_runout(self, cur_lane):
-        """Determine if runout logic should trigger for the current lane."""
+        """Determine if AFC should handle runout for the current lane."""
+
+        # Runout handling is suppressed when both the current lane and its
+        # configured runout lane are AMS lanes that share the same FPS
+        # (extruder). In that scenario the OpenAMS manager will perform the
+        # spool hand-off automatically.
+        if (cur_lane.runout_lane is not None
+                and getattr(cur_lane.unit_obj, "type", "") == "AMS"):
+            ro_lane = self.afc.lanes.get(cur_lane.runout_lane)
+            if (ro_lane is not None
+                    and getattr(ro_lane.unit_obj, "type", "") == "AMS"
+                    and ro_lane.extruder_obj == cur_lane.extruder_obj):
+                return False
+
         return (cur_lane.name == self.afc.function.get_current_lane()
                 and self.afc.function.is_printing()
                 and cur_lane.status not in (AFCLaneState.EJECTING,
@@ -242,11 +255,14 @@ class afcAMS(afcUnit):
             if ro_lane_name:
                 ro_lane = self.afc.lanes.get(ro_lane_name)
                 idx = getattr(ro_lane, "index", 0) - 1 if ro_lane else -1
-                if (ro_lane is not None and idx >= 0 and
-                    getattr(ro_lane, "unit_obj", None) is getattr(lane, "unit_obj", None) and
-                    self.oams_manager is not None and
-                    self.oams_manager.load_spool_for_lane(
-                        fps_name, ro_lane.name, self.oams_name, idx)):
+                ro_unit = getattr(ro_lane, "unit_obj", None) if ro_lane else None
+                if (ro_lane is not None and idx >= 0
+                        and ro_unit is not None
+                        and getattr(ro_unit, "type", "") == "AMS"
+                        and ro_lane.extruder_obj == lane.extruder_obj
+                        and self.oams_manager is not None
+                        and self.oams_manager.load_spool_for_lane(
+                            fps_name, ro_lane.name, ro_unit.oams_name, idx)):
                     cur_ext = self.afc.function.get_current_extruder()
                     if cur_ext in self.afc.tools:
                         self.afc.tools[cur_ext].lane_loaded = ro_lane.name


### PR DESCRIPTION
## Summary
- Avoid AFC runout handling when an AMS lane's backup spool is an AMS lane on the same FPS
- Attempt to reload from the backup AMS lane via OpenAMS before triggering AFC runout

## Testing
- `python -m py_compile klipper/klippy/extras/AFC_AMS.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c5e11f2b5c8326aa6acd56f3d632bb