### PR TITLE
Guard AFC runout when OpenAMS manages spool

### DIFF
--- a/klipper/klippy/extras/AFC_AMS.py
+++ b/klipper/klippy/extras/AFC_AMS.py
@@ -197,15 +197,52 @@ class afcAMS(afcUnit):
         return succeeded
 
     def check_runout(self, cur_lane):
-        """Determine if runout logic should trigger for the current lane."""
+        """Determine if AFC should handle runout for the current lane."""
+
+        unit_type = getattr(cur_lane.unit_obj, "type", "")
+
+        if unit_type == "AMS":
+            # If OpenAMS is actively managing this extruder (a filament group is
+            # loaded on the associated FPS and the currently loaded spool comes
+            # from this AMS unit) then OpenAMS will handle the spool swap and
+            # AFC runout handling should be suppressed.
+            if self.oams_manager is not None:
+                fps_name = None
+                extruder_name = getattr(cur_lane.extruder_obj, "name", None)
+                for name, fps in getattr(self.oams_manager, "fpss", {}).items():
+                    if getattr(fps, "extruder_name", None) == extruder_name:
+                        fps_name = name
+                        break
+
+                if fps_name is not None:
+                    fps_state = self.oams_manager.current_state.fps_state.get(fps_name)
+                    if (fps_state is not None
+                            and fps_state.current_group is not None
+                            and fps_state.current_oams == cur_lane.unit_obj.oams_name):
+                        return False
+
+            # Legacy runout lane check – if both lanes are AMS and on the same
+            # extruder then OpenAMS can perform the rollover automatically.
+            if cur_lane.runout_lane is not None:
+                ro_lane = self.afc.lanes.get(cur_lane.runout_lane)
+                if (ro_lane is not None
+                        and getattr(ro_lane.unit_obj, "type", "") == "AMS"
+                        and ro_lane.extruder_obj == cur_lane.extruder_obj):
+                    return False
+
         return (cur_lane.name == self.afc.function.get_current_lane()
                 and self.afc.function.is_printing()
                 and cur_lane.status not in (AFCLaneState.EJECTING,
                                             AFCLaneState.CALIBRATING))
 
-    def _trigger_runout(self, lane):
-        """Handle runout for lanes without dedicated load sensors."""
-        if self.check_runout(lane):
+    def _trigger_runout(self, lane, force=False):
+        """Handle runout for lanes without dedicated load sensors.
+
+        The ``force`` parameter bypasses ``check_runout`` and executes the
+        appropriate AFC runout routine unconditionally. This is used when
+        OpenAMS reports a runout but cannot reload a backup spool.
+        """
+        if force or self.check_runout(lane):
             if lane.runout_lane is not None:
                 lane._perform_infinite_runout()
             else:
@@ -242,11 +279,14 @@ class afcAMS(afcUnit):
             if ro_lane_name:
                 ro_lane = self.afc.lanes.get(ro_lane_name)
                 idx = getattr(ro_lane, "index", 0) - 1 if ro_lane else -1
-                if (ro_lane is not None and idx >= 0 and
-                    getattr(ro_lane, "unit_obj", None) is getattr(lane, "unit_obj", None) and
-                    self.oams_manager is not None and
-                    self.oams_manager.load_spool_for_lane(
-                        fps_name, ro_lane.name, self.oams_name, idx)):
+                ro_unit = getattr(ro_lane, "unit_obj", None) if ro_lane else None
+                if (ro_lane is not None and idx >= 0
+                        and ro_unit is not None
+                        and getattr(ro_unit, "type", "") == "AMS"
+                        and ro_lane.extruder_obj == lane.extruder_obj
+                        and self.oams_manager is not None
+                        and self.oams_manager.load_spool_for_lane(
+                            fps_name, ro_lane.name, ro_unit.oams_name, idx)):
                     cur_ext = self.afc.function.get_current_extruder()
                     if cur_ext in self.afc.tools:
                         self.afc.tools[cur_ext].lane_loaded = ro_lane.name
@@ -254,7 +294,7 @@ class afcAMS(afcUnit):
                     self.afc.spool._clear_values(lane)
                     self.afc.save_vars()
                     return
-            self._trigger_runout(lane)
+            self._trigger_runout(lane, force=True)
         else:
             self.afc.spool._clear_values(lane)
             self.afc.save_vars()
@@ -323,7 +363,8 @@ class afcAMS(afcUnit):
                     hub.fila.runout_helper.note_filament_present(
                         eventtime, hub_val)
                 self._last_hub_states[hub.name] = hub_val
-                if not hub_val and not load_val:
+                if (not hub_val and not load_val and
+                        self.check_runout(lane)):
                     self._trigger_runout(lane)
 
         return eventtime + self.interval

--- a/klipper/klippy/extras/tests/test_afc_ams.py
+++ b/klipper/klippy/extras/tests/test_afc_ams.py
@@ -1,0 +1,129 @@
+import sys
+import types
+import pathlib
+import sys
+
+# Ensure the 'extras' package used by AFC_AMS can be imported
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
+import extras  # noqa: F401 - ensure package is loaded
+
+afc_unit_mod = types.ModuleType("extras.AFC_unit")
+class afcUnit:  # noqa: N801 - mimic expected class name
+    pass
+afc_unit_mod.afcUnit = afcUnit
+sys.modules["extras.AFC_unit"] = afc_unit_mod
+
+afc_lane_mod = types.ModuleType("extras.AFC_lane")
+class AFCLaneState:  # noqa: N801 - mimic expected class name
+    EJECTING = "Ejecting"
+    CALIBRATING = "Calibrating"
+    LOADED = "Loaded"
+    NONE = "None"
+afc_lane_mod.AFCLaneState = AFCLaneState
+sys.modules["extras.AFC_lane"] = afc_lane_mod
+
+from extras.AFC_AMS import afcAMS, AFCLaneState
+
+class Dummy:
+    pass
+
+class DummyLane:
+    def __init__(self, name, unit_type, extruder, runout_lane=None):
+        self.name = name
+        self.unit_obj = types.SimpleNamespace(type=unit_type, oams_name='oams1')
+        self.extruder_obj = extruder
+        self.runout_lane = runout_lane
+        self.status = AFCLaneState.LOADED
+        self.led_not_ready = self.led_index = 0
+        self.loaded_to_hub = True
+        self._performed = []
+        self.hub_obj = types.SimpleNamespace(
+            name=f'hub_{name}', switch_pin_callback=lambda *a, **k: None
+        )
+        self.load_callback = lambda *a, **k: None
+        self.prep_callback = lambda *a, **k: None
+        self.handle_load_runout = lambda *a, **k: None
+
+    def _perform_infinite_runout(self):
+        self._performed.append('infinite')
+
+    def _perform_pause_runout(self):
+        self._performed.append('pause')
+
+
+class DummyAFC:
+    def __init__(self, lanes, current_lane):
+        self.lanes = {lane.name: lane for lane in lanes}
+        self.function = types.SimpleNamespace(
+            get_current_lane=lambda: current_lane,
+            is_printing=lambda: True,
+            afc_led=lambda *a, **k: None,
+            get_current_extruder=lambda: 'ext1',
+        )
+        self.spool = types.SimpleNamespace(_clear_values=lambda lane: None)
+        self.tools = {}
+        self.led_not_ready = 0
+        self.save_vars = lambda: None
+
+
+def make_ams(lanes, current_lane, oams_manager=None):
+    ams = afcAMS.__new__(afcAMS)
+    ams.afc = DummyAFC(lanes, current_lane)
+    ams.lanes = {lane.name: lane for lane in lanes}
+    ams._last_prep_states = {}
+    ams._last_load_states = {}
+    ams._last_hub_states = {}
+    ams.interval = 1.0
+    ams.reactor = types.SimpleNamespace(
+        monotonic=lambda: 0,
+        NOW=0,
+        register_timer=lambda *a, **k: None,
+        update_timer=lambda *a, **k: None,
+    )
+    ams.oams = None
+    ams.oams_manager = oams_manager
+    return ams
+
+
+def test_check_runout_suppressed_for_same_extruder():
+    extruder = types.SimpleNamespace(name='ext1')
+    lane = DummyLane('L1', 'AMS', extruder, runout_lane='L2')
+    backup = DummyLane('L2', 'AMS', extruder)
+    ams = make_ams([lane, backup], current_lane='L1')
+    assert ams.check_runout(lane) is False
+
+
+def test_check_runout_suppressed_when_oams_group_loaded():
+    extruder = types.SimpleNamespace(name='ext1')
+    lane = DummyLane('L1', 'AMS', extruder)
+    fps_obj = types.SimpleNamespace(extruder_name='ext1')
+    fps_state = types.SimpleNamespace(current_group='T0', current_oams='oams1')
+    oams_mgr = types.SimpleNamespace(
+        fpss={'fps1': fps_obj},
+        current_state=types.SimpleNamespace(fps_state={'fps1': fps_state}),
+    )
+    ams = make_ams([lane], current_lane='L1', oams_manager=oams_mgr)
+    assert ams.check_runout(lane) is False
+
+
+def test_on_oams_runout_forces_afc():
+    extruder = types.SimpleNamespace(name='ext1')
+    lane = DummyLane('L1', 'AMS', extruder)
+    ams = make_ams([lane], current_lane='L1')
+    ams._on_oams_runout('fps1', 'L1', spool_idx=-1)
+    assert lane._performed == ['pause']
+
+
+def test_sync_event_skips_runout_when_openams_handles():
+    extruder = types.SimpleNamespace(name='ext1')
+    lane = DummyLane('L1', 'AMS', extruder, runout_lane='L2')
+    backup = DummyLane('L2', 'AMS', extruder)
+    ams = make_ams([lane, backup], current_lane='L1')
+    # Stub out OpenAMS sensor values indicating runout
+    ams.oams = types.SimpleNamespace(
+        f1s_hes_value=[0], hub_hes_value=[0], determine_current_spool=lambda: None
+    )
+    called = []
+    ams._trigger_runout = lambda *a, **k: called.append(True)
+    ams._sync_event(0)
+    assert not called


### PR DESCRIPTION
## Summary
- Suppress AFC runout when OpenAMS has an active filament group on the same extruder, letting OpenAMS perform the spool swap
- Retain legacy suppression when both current and backup AMS lanes share the extruder
- Add regression tests covering OpenAMS-managed and backup-lane scenarios

## Testing
- `python -m py_compile klipper/klippy/extras/AFC_AMS.py klipper/klippy/extras/tests/test_afc_ams.py`
- `pytest klipper/klippy/extras/tests/test_afc_ams.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5e11f2b5c8326aa6acd56f3d632bb