### PR TITLE
Use hub sensor for AFC runout

### DIFF
--- a/klipper/klippy/extras/AFC_AMS.py
+++ b/klipper/klippy/extras/AFC_AMS.py
@@ -86,7 +86,13 @@ SYNC_INTERVAL = 2.0
 
 
 class afcAMS(afcUnit):
-    """AFK unit that synchronizes lane and hub states with OpenAMS."""
+    """AFK unit that synchronizes lane and hub states with OpenAMS.
+
+    OpenAMS reports separate sensors for spool presence (prep) and for
+    filament traveling through the hub.  Prep sensors track whether a
+    spool is loaded, while hub sensors drive the load state and runout
+    detection.
+    """
 
     def __init__(self, config):
         super().__init__(config)
@@ -226,7 +232,7 @@ class afcAMS(afcUnit):
                             and fps_state.current_group is not None):
                         return False
 
-            # Legacy runout lane check – if both lanes are AMS and on the same
+            # Legacy runout lane check â€“ if both lanes are AMS and on the same
             # extruder then OpenAMS can perform the rollover automatically.
             if cur_lane.runout_lane is not None:
                 ro_lane = self.afc.lanes.get(cur_lane.runout_lane)
@@ -333,11 +339,11 @@ class afcAMS(afcUnit):
 
             try:
                 # OpenAMS exposes separate sensors for spool presence
-                # (f1s_hes_value) and the hub path (hub_hes_value). The
-                # spool sensor should drive both the prep and load states so
-                # that inserting filament reflects immediately in AFC, while
-                # the hub sensor is reported separately for informational
-                # purposes.
+                # (``f1s_hes_value``) and the hub path (``hub_hes_value``).
+                # The prep sensor tracks whether a spool is present so that
+                # inserting filament is immediately reflected in AFC, while
+                # the hub sensor represents filament actually loaded through
+                # the hub and therefore drives runout detection.
                 prep_val = bool(self.oams.f1s_hes_value[idx])
                 hub_val = bool(self.oams.hub_hes_value[idx])
 
@@ -346,7 +352,9 @@ class afcAMS(afcUnit):
                     lane.prep_callback(eventtime, prep_val)
                     self._last_prep_states[lane.name] = prep_val
 
-                load_val = prep_val
+                # Drive the load state from the hub sensor so runout checks
+                # only occur when the hub path goes empty.
+                load_val = hub_val
 
                 last_load = self._last_load_states.get(lane.name)
                 if load_val != last_load:

--- a/klipper/klippy/extras/tests/test_afc_ams.py
+++ b/klipper/klippy/extras/tests/test_afc_ams.py
@@ -1,0 +1,88 @@
+import sys
+import types
+from pathlib import Path
+
+# Ensure the klipper package is importable and provide stub modules expected
+# by AFC_AMS during import.
+repo_root = Path(__file__).resolve().parents[4]
+sys.path.append(str(repo_root / "klipper"))
+
+# Stub out the optional AFC modules that AFC_AMS depends on so the tests do
+# not require the full AFC environment.
+extras = types.ModuleType("extras")
+sys.modules.setdefault("extras", extras)
+sys.modules["extras.AFC_unit"] = types.ModuleType("extras.AFC_unit")
+sys.modules["extras.AFC_lane"] = types.ModuleType("extras.AFC_lane")
+sys.modules["extras.AFC_unit"].afcUnit = object
+sys.modules["extras.AFC_lane"].AFCLaneState = object
+
+from klippy.extras.AFC_AMS import afcAMS
+
+
+class DummyHub:
+    def __init__(self):
+        self.name = "hub1"
+        self.switch_calls = []
+
+    def switch_pin_callback(self, eventtime, state):
+        self.switch_calls.append((eventtime, state))
+
+
+class DummyLane:
+    def __init__(self):
+        self.name = "lane1"
+        self.index = 1
+        self.hub_obj = DummyHub()
+        self.prep_calls = []
+        self.load_calls = []
+        self.runout_triggered = False
+
+    def prep_callback(self, eventtime, state):
+        self.prep_calls.append((eventtime, state))
+
+    def load_callback(self, eventtime, state):
+        self.load_calls.append((eventtime, state))
+
+
+def _build_ams():
+    ams = afcAMS.__new__(afcAMS)
+    ams.lanes = {}
+    ams.oams = type("DummyOAMS", (), {
+        "f1s_hes_value": [True],
+        "hub_hes_value": [True],
+        "determine_current_spool": lambda self: None,
+    })()
+    ams.oams_manager = object()
+    ams._last_prep_states = {}
+    ams._last_load_states = {}
+    ams._last_hub_states = {}
+    ams._is_ams_lane = lambda lane: True
+    ams.check_runout = lambda lane: True
+    ams.interval = 1.0
+
+    def trigger(lane):
+        lane.runout_triggered = True
+
+    ams._trigger_runout = trigger
+    return ams
+
+
+def test_prep_drop_no_runout():
+    ams = _build_ams()
+    lane = DummyLane()
+    ams.lanes[lane.name] = lane
+
+    # Initial sync with both sensors True
+    ams._sync_event(0.0)
+    initial_load_calls = list(lane.load_calls)
+
+    # Only the prep sensor drops
+    ams.oams.f1s_hes_value[0] = False
+    ams._sync_event(1.0)
+
+    assert lane.prep_calls[-1] == (1.0, False)
+    assert lane.load_calls == initial_load_calls, (
+        "Load callback should not fire when hub remains True"
+    )
+    assert not lane.runout_triggered, "Runout should not trigger on prep drop alone"
+


### PR DESCRIPTION
## Summary
- Use hub sensor value for AFC load state so runout triggers only when hub path empties
- Clarify in docs/comments that prep sensors track spool presence while hub sensors drive runout
- Add regression test ensuring prep sensor drop alone doesn't trigger runout

## Testing
- `pytest klipper/klippy/extras/tests/test_afc_ams.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c6382e9ddc8326b716d78b76e9c37f