### PR TITLE
Respect OpenAMS runout during prep sensor events

### DIFF
--- a/AFC-Klipper-Add-On/extras/AFC_lane.py
+++ b/AFC-Klipper-Add-On/extras/AFC_lane.py
@@ -611,11 +611,18 @@ class AFCLane:
                         self.afc.spool._set_values(self)
 
                 elif self.prep_state == False and self.name == self.afc.current and self.afc.function.is_printing() and self.load_state and self.status != AFCLaneState.EJECTING:
-                    # Checking to make sure runout_lane is set
-                    if self.runout_lane is not None:
-                        self._perform_infinite_runout()
-                    else:
-                        self._perform_pause_runout()
+                    if self.unit_obj.check_runout(self):
+                        # Checking to make sure runout_lane is set
+                        if self.runout_lane is not None:
+                            self._perform_infinite_runout()
+                        else:
+                            self._perform_pause_runout()
+                    elif self.status != "calibrating":
+                        self.afc.function.afc_led(self.led_not_ready, self.led_index)
+                        self.status = AFCLaneState.NONE
+                        self.loaded_to_hub = False
+                        self.afc.spool._clear_values(self)
+                        self.afc.function.afc_led(self.afc.led_not_ready, self.led_index)
 
                 elif self.prep_state == True and self.load_state == True and not self.afc.function.is_printing():
                     message = 'Cannot load {} load sensor is triggered.'.format(self.name)


### PR DESCRIPTION
## Summary
- defer AFC infinite spool to OpenAMS when prep sensor indicates runout

## Testing
- `python -m py_compile AFC-Klipper-Add-On/extras/AFC_lane.py`


------
https://chatgpt.com/codex/tasks/task_e_68c6416b59048326897b4560964c04d1