### PR TITLE
Coordinate AFC infinite spool with OpenAMS reloads

### DIFF
--- a/AFC-Klipper-Add-On/extras/AFC_lane.py
+++ b/AFC-Klipper-Add-On/extras/AFC_lane.py
@@ -521,6 +521,16 @@ class AFCLane:
 
     def load_callback(self, eventtime, state):
         self.load_state = state
+        if (not state
+                and getattr(self.unit_obj, "oams_manager", None) is not None
+                and hasattr(self.unit_obj, "_is_ams_lane")
+                and self.unit_obj._is_ams_lane(self)):
+            # When OpenAMS manages this AMS lane, defer runout handling until
+            # the manager reports a hub runout so AFC's infinite spool logic
+            # doesn't trigger early on prep/load runout events.
+            self.afc.save_vars()
+            return
+
         if self.printer.state_message == 'Printer is ready' and self.unit_obj.type == "HTLF":
             self.prep_state = state
 
@@ -530,13 +540,15 @@ class AFCLane:
                 self.material = self.afc.default_material_type
                 self.weight = 1000 # Defaulting weight to 1000 upon load
             else:
-                if self.unit_obj.check_runout(self):
+                runout = self.unit_obj.check_runout(self)
+                if runout:
                     # Checking to make sure runout_lane is set
                     if self.runout_lane is not None:
                         self._perform_infinite_runout()
                     else:
                         self._perform_pause_runout()
-                elif self.status != "calibrating":
+                elif (self.status != "calibrating"
+                        and getattr(self.unit_obj, "oams_manager", None) is None):
                     self.afc.function.afc_led(self.led_not_ready, self.led_index)
                     self.status = AFCLaneState.NONE
                     self.loaded_to_hub = False
@@ -611,11 +623,12 @@ class AFCLane:
                         self.afc.spool._set_values(self)
 
                 elif self.prep_state == False and self.name == self.afc.current and self.afc.function.is_printing() and self.load_state and self.status != AFCLaneState.EJECTING:
-                    # Checking to make sure runout_lane is set
-                    if self.runout_lane is not None:
-                        self._perform_infinite_runout()
-                    else:
-                        self._perform_pause_runout()
+                    if self.unit_obj.check_runout(self):
+                        # Checking to make sure runout_lane is set
+                        if self.runout_lane is not None:
+                            self._perform_infinite_runout()
+                        else:
+                            self._perform_pause_runout()
 
                 elif self.prep_state == True and self.load_state == True and not self.afc.function.is_printing():
                     message = 'Cannot load {} load sensor is triggered.'.format(self.name)

--- a/klipper/klippy/extras/AFC_AMS.py
+++ b/klipper/klippy/extras/AFC_AMS.py
@@ -214,23 +214,10 @@ class afcAMS(afcUnit):
     def check_runout(self, cur_lane):
         """Determine if AFC should handle runout for the current lane."""
         if self._is_ams_lane(cur_lane):
-            # If OpenAMS is actively managing this extruder (a filament group is
-            # loaded on the associated FPS and the currently loaded spool comes
-            # from this AMS unit) then OpenAMS will handle the spool swap and
-            # AFC runout handling should be suppressed.
+            # When the OpenAMS manager is present defer runout handling so it
+            # can attempt a spool swap before AFC intervenes.
             if self.oams_manager is not None:
-                fps_name = None
-                extruder_name = getattr(cur_lane.extruder_obj, "name", None)
-                for name, fps in getattr(self.oams_manager, "fpss", {}).items():
-                    if getattr(fps, "extruder_name", None) == extruder_name:
-                        fps_name = name
-                        break
-
-                if fps_name is not None:
-                    fps_state = self.oams_manager.current_state.fps_state.get(fps_name)
-                    if (fps_state is not None
-                            and fps_state.current_group is not None):
-                        return False
+                return False
 
             # Legacy runout lane check - if both lanes are AMS and on the same
             # extruder then OpenAMS can perform the rollover automatically.
@@ -288,26 +275,37 @@ class afcAMS(afcUnit):
                 hub.fila.runout_helper.note_filament_present(eventtime, False)
         if spool_idx < 0:
             ro_lane_name = lane.runout_lane
-            if ro_lane_name:
-                ro_lane = self.afc.lanes.get(ro_lane_name)
-                idx = getattr(ro_lane, "index", 0) - 1 if ro_lane else -1
-                ro_unit = getattr(ro_lane, "unit_obj", None) if ro_lane else None
-                if (ro_lane is not None and idx >= 0
-                        and ro_unit is not None
-                        and self._is_ams_lane(ro_lane)
-                        and getattr(ro_lane.extruder_obj, "name", None)
-                        == getattr(lane.extruder_obj, "name", None)
-                        and self.oams_manager is not None
-                        and self.oams_manager.load_spool_for_lane(
-                            fps_name, ro_lane.name, ro_unit.oams_name, idx)):
-                    cur_ext = self.afc.function.get_current_extruder()
-                    if cur_ext in self.afc.tools:
-                        self.afc.tools[cur_ext].lane_loaded = ro_lane.name
-                    ro_lane.unit_obj.lane_loaded(ro_lane)
-                    self.afc.spool._clear_values(lane)
-                    self.afc.save_vars()
-                    return
+            ro_lane = self.afc.lanes.get(ro_lane_name) if ro_lane_name else None
+            idx = ((getattr(ro_lane, "index", 0) - 1) % 4
+                   if ro_lane else -1)
+            ro_unit = getattr(ro_lane, "unit_obj", None) if ro_lane else None
+            if (ro_lane is not None and idx >= 0
+                    and ro_unit is not None
+                    and self._is_ams_lane(ro_lane)
+                    and getattr(ro_lane.extruder_obj, "name", None)
+                    == getattr(lane.extruder_obj, "name", None)
+                    and self.oams_manager is not None
+                    and self.oams_manager.load_spool_for_lane(
+                        fps_name, ro_lane.name, ro_unit.oams_name, idx)):
+                cur_ext = self.afc.function.get_current_extruder()
+                if cur_ext in self.afc.tools:
+                    self.afc.tools[cur_ext].lane_loaded = ro_lane.name
+                ro_lane.unit_obj.lane_loaded(ro_lane)
+                self.afc.spool._clear_values(lane)
+                self.afc.save_vars()
+                return
             self._trigger_runout(lane, force=True)
+            if self.oams_manager is not None:
+                fps_state = self.oams_manager.current_state.fps_state.get(fps_name)
+                if fps_state is not None:
+                    fps_state.state_name = "LOADED"
+                    if ro_lane_name and ro_lane and ro_unit and idx >= 0:
+                        fps_state.current_group = ro_lane.name
+                        fps_state.current_oams = ro_unit.oams_name
+                        fps_state.current_spool_idx = idx
+                if self.oams_manager.runout_monitor is not None:
+                    self.oams_manager.runout_monitor.reset()
+                    self.oams_manager.runout_monitor.start()
         else:
             self.afc.spool._clear_values(lane)
             self.afc.save_vars()

--- a/klipper_openams/src/oams_manager.py
+++ b/klipper_openams/src/oams_manager.py
@@ -687,8 +687,6 @@ class OAMSManager:
                         else:
                             logging.error(f"OAMS: Failed to load spool: {message}")
                             break
-                self._pause_printer_message(
-                    "No spool available for group %s" % fps_state.current_group)
                 self.runout_monitor.paused()
                 if self.runout_callback is not None:
                     self.runout_callback(
@@ -696,6 +694,10 @@ class OAMSManager:
                         fps_state.current_group,
                         -1,
                     )
+                    if fps_state.state_name == "LOADED":
+                        return
+                self._pause_printer_message(
+                    "No spool available for group %s" % fps_state.current_group)
                 return
 
             self.runout_monitor = OAMSRunoutMonitor(self.printer, fps_name, self.fpss[fps_name], fps_state, self.oams, _reload_callback, reload_before_toolhead_distance=self.reload_before_toolhead_distance)


### PR DESCRIPTION
## Summary
- avoid clearing lane state when OpenAMS manager should handle runouts
- update OpenAMS FPS state and restart monitoring after AFC fallback reloads
- defer AFC runout handling when OpenAMS manages an AMS lane so spool swap waits on hub runout

## Testing
- `python -m py_compile AFC-Klipper-Add-On/extras/AFC_lane.py klipper/klippy/extras/AFC_AMS.py klipper_openams/src/oams_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_68c6416b59048326897b4560964c04d1