### PR TITLE
Expose runout callback for AFC integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+## Sovoron Klipper Modifications
+
+This fork integrates OpenAMS filament runout handling with AFC. The OAMS manager exposes a runout callback and AFC's AMS unit registers for those events to switch spools automatically.

--- a/klipper/klippy/extras/AFC_AMS.py
+++ b/klipper/klippy/extras/AFC_AMS.py
@@ -98,6 +98,8 @@ class afcAMS(afcUnit):
         self.timer = self.reactor.register_timer(self._sync_event)
         self.printer.register_event_handler("klippy:ready", self.handle_ready)
 
+        self.oams_manager = None
+
         # Track last sensor states so callbacks only trigger on changes
         self._last_prep_states = {}
         self._last_load_states = {}
@@ -203,58 +205,128 @@ class afcAMS(afcUnit):
                                             AFCLaneState.CALIBRATING))
 
     def handle_ready(self):
-        # Resolve OpenAMS object and start periodic polling
+        # Resolve OpenAMS objects and register for runout callbacks
         self.oams = self.printer.lookup_object("oams " + self.oams_name, None)
+        self.oams_manager = self.printer.lookup_object("oams_manager", None)
+        if self.oams_manager is not None:
+            self.oams_manager.register_runout_callback(self._on_oams_runout)
         self.reactor.update_timer(self.timer, self.reactor.NOW)
 
+    def _on_oams_runout(self, fps_name, spool_idx):
+        """Forward OpenAMS runout events to the active lane.
+
+        When a new spool is loaded on the same FPS, switch to its lane by
+        issuing the corresponding ``T#`` command. If no spool could be loaded,
+        invoke AFC's standard runout handling for the active lane.
+        """
+        lane_name = self.afc.function.get_current_lane()
+        lane = self.lanes.get(lane_name)
+        if lane is None:
+            return
+
+        if spool_idx >= 0 and self.oams_manager is not None:
+            # Determine which OAMS and bay were loaded and compute the global
+            # lane number so the printer switches tools accordingly.
+            fps_state = self.oams_manager.current_state.fps_state.get(fps_name)
+            if fps_state is None:
+                return
+            oams_obj = self.oams_manager.oams.get(fps_state.current_oams)
+            if oams_obj is None:
+                return
+            tool = (oams_obj.oams_idx - 1) * 4 + spool_idx + 1
+            gcode = self.printer.lookup_object("gcode")
+            gcode.run_script_from_command(f"T{tool}")
+            return
+
+        # OpenAMS could not reload a spool automatically. If the current lane
+        # has an infinite-spool fallback that is an AMS lane on the same FPS,
+        # attempt to load it via OpenAMS before falling back to AFC logic.
+        runout_name = getattr(lane, "runout_lane", None)
+        ro_lane = self.afc.lanes.get(runout_name) if runout_name else None
+        if (
+            ro_lane is not None
+            and isinstance(getattr(ro_lane, "unit_obj", None), afcAMS)
+            and self.oams_manager is not None
+        ):
+            ro_unit = ro_lane.unit_obj
+            bay = (getattr(ro_lane, "index", 0) - 1) % 4
+            if self.oams_manager.load_spool_for_lane(
+                fps_name, ro_unit.oams_name, bay
+            ):
+                tool = (
+                    self.oams_manager.oams[ro_unit.oams_name].oams_idx - 1
+                ) * 4 + bay + 1
+                gcode = self.printer.lookup_object("gcode")
+                gcode.run_script_from_command(f"T{tool}")
+                pause = self.printer.lookup_object("pause_resume", None)
+                if pause is not None:
+                    pause.send_resume_command()
+                return
+
+        eventtime = self.reactor.monotonic()
+        lane.handle_load_runout(eventtime, False)
+
     def _sync_event(self, eventtime):
+        if self.oams is None:
+            return eventtime + self.interval
+
+        # Request updated sensor values from the OpenAMS controller so
+        # new spools inserted into empty bays are detected.
         try:
-            if self.oams is None:
-                return eventtime + self.interval
+            self.oams.determine_current_spool()
+        except Exception:
+            pass
 
-            # Request updated sensor values from the OpenAMS controller so
-            # new spools inserted into empty bays are detected.
+        # Iterate through lanes belonging to this unit
+        prep_values = self.oams.f1s_hes_value
+        hub_values = getattr(self.oams, "hub_hes_value", [])
+        sensor_len = len(prep_values)
+        if sensor_len == 0:
+            return eventtime + self.interval
+
+        for lane in list(self.lanes.values()):
             try:
-                self.oams.determine_current_spool()
-            except Exception:
-                pass
-
-            # Iterate through lanes belonging to this unit
-            for lane in list(self.lanes.values()):
                 idx = getattr(lane, "index", 0) - 1
                 if idx < 0:
                     continue
+                # Each AMS unit only reports four bays, but AFC lane
+                # indices may be global across multiple units. Wrap the
+                # lane index so the correct sensor slot is used.
+                idx %= sensor_len
 
-                # OpenAMS exposes separate sensors for spool presence (prep)
-                # and filament loaded into the hub (load). Track changes for
-                # each independently so lane callbacks mirror physical state.
-                prep_val = bool(self.oams.f1s_hes_value[idx])
+                # Load and prep sensors for AMS lanes both originate from the
+                # F1S HES values. Hub sensors report filament at the follower
+                # gears. Consider the lane "loaded" until both sensors are
+                # clear so OpenAMS can finish coasting before AFC runs runout.
+                prep_val = bool(prep_values[idx])
+                hub_state = bool(hub_values[idx]) if idx < len(hub_values) else False
+
                 last_prep = self._last_prep_states.get(lane.name)
                 if prep_val != last_prep:
                     lane.prep_callback(eventtime, prep_val)
                     self._last_prep_states[lane.name] = prep_val
 
-                load_val = bool(self.oams.hub_hes_value[idx])
+                load_val = prep_val or hub_state
                 last_load = self._last_load_states.get(lane.name)
                 if load_val != last_load:
-                    lane.handle_load_runout(eventtime, load_val)
+                    lane.load_callback(eventtime, load_val)
                     self._last_load_states[lane.name] = load_val
 
+                # Update dedicated hub sensor state
                 hub = getattr(lane, "hub_obj", None)
                 if hub is None:
                     continue
 
                 last_hub = self._last_hub_states.get(hub.name)
-                if load_val != last_hub:
-                    hub.switch_pin_callback(eventtime, load_val)
+                if hub_state != last_hub:
+                    hub.switch_pin_callback(eventtime, hub_state)
                     if hasattr(hub, "fila"):
                         hub.fila.runout_helper.note_filament_present(
-                            eventtime, load_val)
-                    self._last_hub_states[hub.name] = load_val
-
-        except Exception:
-            # Avoid breaking the reactor loop if OpenAMS query fails
-            pass
+                            eventtime, hub_state)
+                    self._last_hub_states[hub.name] = hub_state
+            except Exception:
+                # Skip lanes that can't be queried but continue updating others
+                continue
 
         return eventtime + self.interval
 

--- a/printer_data/config/oamsc.cfg
+++ b/printer_data/config/oamsc.cfg
@@ -289,4 +289,9 @@ extruder: extruder5
 
 [oams_manager]
 
+# Delay OpenAMS spool reloads until the toolhead has moved 100mm past
+# the hub sensor. Negative values add extra coasting before a reload is
+# attempted.
+reload_before_toolhead_distance: -100
+
 [include oams_macros.cfg]


### PR DESCRIPTION
## Summary
- allow external modules to register for OpenAMS runout events
- afcAMS hooks into that callback and forwards failed reloads to the current lane
- after OpenAMS reloads a spool on the same FPS, automatically issue the corresponding `T#` command to switch lanes
- prefer OpenAMS reloads for same-FPS infinite spool failovers before invoking AFC's custom load command
- runout monitor still coasts an extra 30 mm before loading the next spool
- fix AMS lane synchronization so all bays update independently
- wrap lane indexes per AMS so hub sensors report correctly across units
- track AMS hub sensors separately from spool presence and report hub status from the real F1S hub sensor
- expose `reload_before_toolhead_distance` in config to delay spool reloads
- read hub sensors independently of prep sensors so newly inserted spools register without a hub trigger
- mirror spool presence on idle AMS hub indicators so hubs no longer appear empty
- use F1S HES readings for both prep and load sensors and obtain hub states from F1S hub sensors, keeping prep/load in sync
- restore AMS lane updates to use `load_callback`, ensuring hub indicators reflect real `hub_hes_value` readings
- load fallback AMS lanes through OpenAMS when the infinite-spool lane shares the same FPS, resuming the print without invoking AFC runout
- keep AMS lanes "loaded" until both spool and hub sensors clear so OpenAMS can swap spools before AFC triggers runout

## Testing
- `python -m py_compile klipper/klippy/extras/AFC_AMS.py klipper_openams/src/oams_manager.py && echo 'py_compile success'`


------
https://chatgpt.com/codex/tasks/task_e_68c32caaa3608326b62f65e640b6b9d2