### PR TITLE
Expose runout callback for AFC integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+## Sovoron Klipper Modifications
+
+This fork integrates OpenAMS filament runout handling with AFC. The OAMS manager exposes a runout callback and AFC's AMS unit registers for those events to switch spools automatically.

--- a/printer_data/config/oamsc.cfg
+++ b/printer_data/config/oamsc.cfg
@@ -289,4 +289,9 @@ extruder: extruder5
 
 [oams_manager]
 
+# Delay OpenAMS spool reloads until the toolhead has moved 100mm past
+# the hub sensor. Negative values add extra coasting before a reload is
+# attempted.
+reload_before_toolhead_distance: -100
+
 [include oams_macros.cfg]


### PR DESCRIPTION
## Summary
- allow external modules to register for OpenAMS runout events
- afcAMS hooks into that callback and forwards failed reloads to the current lane
- after OpenAMS reloads a spool on the same FPS, automatically issue the corresponding `OAMSM_LOAD_FILAMENT` command instead of a `T#` change
- prefer OpenAMS reloads for same-FPS infinite spool failovers before invoking AFC's custom load command
- runout monitor still coasts an extra 30 mm before loading the next spool
- fix AMS lane synchronization so all bays update independently
- wrap lane indexes per AMS so hub sensors report correctly across units
- track AMS hub sensors separately from spool presence and report hub status from the real F1S hub sensor
- expose `reload_before_toolhead_distance` in config to delay spool reloads
- read hub sensors independently of prep sensors so newly inserted spools register without a hub trigger
- mirror spool presence on idle AMS hub indicators so hubs no longer appear empty
- use F1S HES readings for both prep and load sensors and obtain hub states from F1S hub sensors, keeping prep/load in sync
- restore AMS lane updates to use `load_callback`, ensuring hub indicators reflect real `hub_hes_value` readings
- load fallback AMS lanes through OpenAMS when the infinite-spool lane shares the same FPS, resuming the print without invoking AFC runout
- keep AMS lanes "loaded" until both spool and hub sensors clear so OpenAMS can swap spools before AFC triggers runout
- mark FPS state as unloaded and invoke `OAMSM_LOAD_FILAMENT` for same-FPS runout lanes instead of `T#` tool changes

## Testing
- `python -m py_compile klipper/klippy/extras/AFC_AMS.py klipper_openams/src/oams_manager.py`

------
https://chatgpt.com/codex/tasks/task_e_68c32caaa3608326b62f65e640b6b9d2