### PR TITLE
Use FPS lookup for AMS runout fallback

### DIFF
--- a/klipper/klippy/extras/AFC_AMS.py
+++ b/klipper/klippy/extras/AFC_AMS.py
@@ -243,7 +243,9 @@ class afcAMS(afcUnit):
         ):
             # Only attempt an OpenAMS reload if the fallback lane resides on
             # the same FPS as the lane that ran out.
-            ro_fps = self.oams_manager.group_fps_name(ro_lane.map)
+            ro_fps = self.oams_manager.fps_name_for_oams(
+                ro_lane.unit_obj.oams_name
+            )
             if ro_fps == fps_name:
                 fps_state = self.oams_manager.current_state.fps_state.get(fps_name)
                 if fps_state is not None:
@@ -252,17 +254,19 @@ class afcAMS(afcUnit):
                     fps_state.current_group = None
                     fps_state.current_oams = None
                     fps_state.current_spool_idx = None
-                gcode = self.printer.lookup_object("gcode")
-                gcode.run_script_from_command(
-                    f"OAMSM_LOAD_FILAMENT GROUP={ro_lane.map}"
+                loaded = self.oams_manager.load_spool_for_lane(
+                    fps_name,
+                    ro_lane.unit_obj.oams_name,
+                    ro_lane.index - 1,
                 )
-                if hasattr(self.oams_manager, "runout_monitor"):
-                    self.oams_manager.runout_monitor.reset()
-                    self.oams_manager.runout_monitor.start()
-                pause = self.printer.lookup_object("pause_resume", None)
-                if pause is not None:
-                    pause.send_resume_command()
-                return
+                if loaded:
+                    if hasattr(self.oams_manager, "runout_monitor"):
+                        self.oams_manager.runout_monitor.reset()
+                        self.oams_manager.runout_monitor.start()
+                    pause = self.printer.lookup_object("pause_resume", None)
+                    if pause is not None:
+                        pause.send_resume_command()
+                    return
 
         eventtime = self.reactor.monotonic()
         lane.handle_load_runout(eventtime, False)

--- a/klipper_openams/src/oams_manager.py
+++ b/klipper_openams/src/oams_manager.py
@@ -514,6 +514,12 @@ class OAMSManager:
                             if fps_oam in c_group.oams:
                                 return fps_name
         return None
+
+    def fps_name_for_oams(self, oams_name):
+        for fps_name, fps in self.fpss.items():
+            if oams_name in fps.oams:
+                return fps_name
+        return None
     
     cmd_UNLOAD_FILAMENT_help = "Unload a spool from any of the OAMS if any is loaded"
     def cmd_UNLOAD_FILAMENT(self, gcmd):


### PR DESCRIPTION
## Summary
- add `fps_name_for_oams` helper to locate FPS for a given OAMS unit
- use helper in AFC runout handler and load fallback spool directly

## Testing
- `python -m py_compile klipper_openams/src/oams_manager.py klipper/klippy/extras/AFC_AMS.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c74cbd68648326aba6708500494fe5