### PR TITLE
Use FPS lookup for AMS runout fallback

### DIFF
--- a/klipper_openams/src/oams_manager.py
+++ b/klipper_openams/src/oams_manager.py
@@ -514,6 +514,17 @@ class OAMSManager:
                             if fps_oam in c_group.oams:
                                 return fps_name
         return None
+
+    def fps_name_for_oams(self, oams_name):
+        logging.info("OAMS manager: resolving FPS for %s", oams_name)
+        for fps_name, fps in self.fpss.items():
+            if oams_name in fps.oams:
+                logging.info(
+                    "OAMS manager: %s belongs to %s", oams_name, fps_name
+                )
+                return fps_name
+        logging.info("OAMS manager: %s not found in any FPS", oams_name)
+        return None
     
     cmd_UNLOAD_FILAMENT_help = "Unload a spool from any of the OAMS if any is loaded"
     def cmd_UNLOAD_FILAMENT(self, gcmd):


### PR DESCRIPTION
## Summary
- add `fps_name_for_oams` helper to locate FPS for a given OAMS unit
- use helper in AFC runout handler and load fallback spool directly
- suppress AFC runout macros while OpenAMS reloads filament
- update AFC state after fallback load so runout macros aren't triggered
- add debug logging around runout handling and FPS lookups to aid troubleshooting

## Testing
- `python -m py_compile klipper/klippy/extras/AFC_AMS.py klipper_openams/src/oams_manager.py AFC-Klipper-Add-On/extras/AFC_lane.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c74cbd68648326aba6708500494fe5