### PR TITLE
Use FPS lookup for AMS runout fallback

### DIFF
--- a/klipper_openams/src/oams_manager.py
+++ b/klipper_openams/src/oams_manager.py
@@ -9,6 +9,7 @@ import time
 from functools import partial
 from collections import deque
 from typing import Optional, Tuple, Dict, List, Any, Callable
+from .filament_group import FilamentGroup
 
 # Configuration constants
 PAUSE_DISTANCE = 60  # mm to pause before coasting follower
@@ -514,6 +515,88 @@ class OAMSManager:
                             if fps_oam in c_group.oams:
                                 return fps_name
         return None
+
+    def fps_name_for_oams(self, oams_name):
+        logging.info("OAMS manager: resolving FPS for %s", oams_name)
+        for fps_name, fps in self.fpss.items():
+            if oams_name in fps.oams:
+                logging.info(
+                    "OAMS manager: %s belongs to %s", oams_name, fps_name
+                )
+                return fps_name
+        logging.info("OAMS manager: %s not found in any FPS", oams_name)
+        return None
+
+    def ensure_group_for_lanes(self, group_name, lane_a, lane_b):
+        """Create or remove a filament group for two AMS lanes.
+
+        If ``lane_b`` is ``None``, any existing group named ``group_name`` is
+        removed.  Otherwise, a group containing the two lanes is created or
+        updated, provided both lanes reside on the same FPS controller.
+        """
+        fps_state = None
+        if lane_b is None:
+            if group_name in self.filament_groups:
+                logging.info("OAMS manager: removing group %s", group_name)
+                del self.filament_groups[group_name]
+            # Clear the active group if it matched the removed group
+            for state in self.current_state.fps_state.values():
+                if state.current_group == group_name:
+                    state.current_group = None
+            return
+
+        oam_a = self.oams.get(lane_a.unit_obj.oams_name)
+        oam_b = self.oams.get(lane_b.unit_obj.oams_name)
+        if oam_a is None or oam_b is None:
+            return
+        fps_a = self.fps_name_for_oams(oam_a.name)
+        fps_b = self.fps_name_for_oams(oam_b.name)
+        if fps_a != fps_b or fps_a is None:
+            logging.info(
+                "OAMS manager: lanes %s and %s are on different FPS (%s vs %s)",
+                lane_a.name,
+                lane_b.name,
+                fps_a,
+                fps_b,
+            )
+            return
+
+        bay_count_a = len(getattr(oam_a, "f1s_hes_value", [])) or 4
+        bay_count_b = len(getattr(oam_b, "f1s_hes_value", [])) or 4
+        bay_a = (lane_a.index - 1) % bay_count_a
+        bay_b = (lane_b.index - 1) % bay_count_b
+
+        group = self.filament_groups.get(group_name)
+        if group is None:
+            group = FilamentGroup.__new__(FilamentGroup)
+            group.printer = self.printer
+            group.group_name = group_name
+            group.bays = []
+            group.oams = []
+            self.filament_groups[group_name] = group
+
+        group.bays = [(oam_a, bay_a), (oam_b, bay_b)]
+        group.oams = [oam_a] if oam_a is oam_b else [oam_a, oam_b]
+        logging.info(
+            "OAMS manager: group %s set to %s-%s, %s-%s",
+            group_name,
+            oam_a.name,
+            bay_a,
+            oam_b.name,
+            bay_b,
+        )
+
+        # Update FPS state if one of the lanes in the new group is currently loaded
+        fps_state = self.current_state.fps_state.get(fps_a)
+        if fps_state is not None:
+            if (
+                fps_state.current_oams == oam_a.name
+                and fps_state.current_spool_idx == bay_a
+            ) or (
+                fps_state.current_oams == oam_b.name
+                and fps_state.current_spool_idx == bay_b
+            ):
+                fps_state.current_group = group_name
     
     cmd_UNLOAD_FILAMENT_help = "Unload a spool from any of the OAMS if any is loaded"
     def cmd_UNLOAD_FILAMENT(self, gcmd):


### PR DESCRIPTION
## Summary
- add `fps_name_for_oams` helper to locate FPS for a given OAMS unit
- inject runout and filament-group hooks from `AFC_AMS.py` so lane and spool modules remain unchanged
- compute local bay index and update active group when loading fallback lane
- suppress AFC runout macros while OpenAMS reloads filament
- add debug logging around runout handling and FPS lookups to aid troubleshooting
- build filament groups dynamically when `SET_RUNOUT` links two AMS lanes on the same FPS
- fix relative import for `FilamentGroup` to prevent connect-time error
- sync FPS `current_group` when configuring or removing runout so OpenAMS tracks the active lane

## Testing
- `python -m py_compile klipper_openams/src/oams_manager.py klipper/klippy/extras/AFC_AMS.py AFC-Klipper-Add-On/extras/AFC_lane.py AFC-Klipper-Add-On/extras/AFC_spool.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c74cbd68648326aba6708500494fe5