### PR TITLE
Add AMS buffer status reporting

### DIFF
--- a/AFC-Klipper-Add-On/extras/AFC_lane.py
+++ b/AFC-Klipper-Add-On/extras/AFC_lane.py
@@ -61,6 +61,7 @@ class AFCLane:
         self.hub_obj            = None
         self.buffer_obj         = None
         self.extruder_obj       = None
+        self.ams_fps_status     = None
 
         #stored status variables
         self.fullname           = config.get_name()
@@ -840,7 +841,16 @@ class AFCLane:
         if self.buffer_obj is not None:
             return self.buffer_obj.buffer_status()
 
-        else: return None
+        if (self.unit_obj is not None and getattr(self.unit_obj, "type", None) == "AMS"
+                and self.name == self.afc.current):
+            if self.ams_fps_status is None:
+                return None
+            try:
+                return f"{float(self.ams_fps_status):.2f}"
+            except (TypeError, ValueError):
+                return None
+
+        return None
 
     def get_toolhead_pre_sensor_state(self):
         """

--- a/klipper/klippy/extras/AFC_AMS.py
+++ b/klipper/klippy/extras/AFC_AMS.py
@@ -207,6 +207,9 @@ class afcAMS(afcUnit):
                 if idx < 0:
                     continue
 
+                if hasattr(lane, "ams_fps_status"):
+                    lane.ams_fps_status = getattr(self.oams, "fps_value", None)
+
                 lane_val = bool(self.oams.f1s_hes_value[idx])
                 last_lane = self._last_lane_states.get(lane.name)
                 if lane_val != last_lane:


### PR DESCRIPTION
## Summary
- store the latest AMS FPS reading on each lane so it can be reused when no physical buffer is attached
- expose the formatted FPS value through `buffer_status()` for the active AMS lane while preserving existing behaviour otherwise
- refresh each AMS lane with the current OpenAMS FPS reading during periodic syncs

## Testing
- python - <<'PY' ... (stub verification of buffer_status behaviour)


------
https://chatgpt.com/codex/tasks/task_e_68cb78ec5480832689c775686a93513a