### PR TITLE
Fix reverse filter to return list

### DIFF
--- a/klipper/klippy/extras/gcode_macro.py
+++ b/klipper/klippy/extras/gcode_macro.py
@@ -78,6 +78,16 @@ class PrinterGCodeMacro:
     def __init__(self, config):
         self.printer = config.get_printer()
         self.env = jinja2.Environment('{%', '%}', '{', '}')
+        def _reverse_filter(value):
+            if isinstance(value, (str, bytes)):
+                return value[::-1]
+            try:
+                return list(reversed(value))
+            except TypeError:
+                seq = list(value)
+                seq.reverse()
+                return seq
+        self.env.filters['reverse'] = _reverse_filter
     def load_template(self, config, option, default=None):
         name = "%s:%s" % (config.get_name(), option)
         if default is None:


### PR DESCRIPTION
## Summary
- override the gcode macro Jinja reverse filter so it always returns a concrete sequence
- prevent list_reverseiterator objects that break filters expecting len()

## Testing
- python -m compileall klipper/klippy/extras/gcode_macro.py

------
https://chatgpt.com/codex/tasks/task_e_68cc6bae08c083268e1fc3849a05e650