### PR TITLE
Add debounce handling and runout controls

### DIFF
--- a/AFC-Klipper-Add-On/extras/AFC.py
+++ b/AFC-Klipper-Add-On/extras/AFC.py
@@ -203,6 +203,9 @@ class afc:
         self.enable_assist          = config.getboolean("enable_assist",        True)
         # Weight spool has to be below to activate print assist
         self.enable_assist_weight   = config.getfloat("enable_assist_weight",   500.0)
+        self.enable_hub_runout      = config.getboolean("enable_hub_runout",    True)
+        self.enable_tool_runout     = config.getboolean("enable_tool_runout",   True)
+        self.debounce_delay         = config.getfloat("debounce_delay",         0.)
 
         self.debug                  = config.getboolean('debug', False)             # Setting to True turns on more debugging to show on console
         self.testing                = config.getboolean('testing', False)           # Set to true for testing only so that failure states can be tested without stats being reset
@@ -325,10 +328,10 @@ class afc:
         try:
             self.bypass = self.printer.lookup_object('filament_switch_sensor bypass').runout_helper
         except:
-            self.bypass = add_filament_switch("filament_switch_sensor virtual_bypass", "afc_virtual_bypass:virtual_bypass", self.printer ).runout_helper
+            self.bypass = add_filament_switch("virtual_bypass", "afc_virtual_bypass:virtual_bypass", self.printer ).runout_helper
 
         if self.show_quiet_mode:
-            self.quiet_switch = add_filament_switch("filament_switch_sensor quiet_mode", "afc_quiet_mode:afc_quiet_mode", self.printer ).runout_helper
+            self.quiet_switch = add_filament_switch("quiet_mode", "afc_quiet_mode:afc_quiet_mode", self.printer ).runout_helper
 
         # Register G-Code commands for macros we don't want to show up in mainsail/fluidd
         self.gcode.register_command('TOOL_UNLOAD',          self.cmd_TOOL_UNLOAD,           desc=self.cmd_TOOL_UNLOAD_help)

--- a/AFC-Klipper-Add-On/extras/AFC_HTLF.py
+++ b/AFC-Klipper-Add-On/extras/AFC_HTLF.py
@@ -47,10 +47,8 @@ class AFC_HTLF(afcBoxTurtle):
         buttons = self.printer.load_object(config, "buttons")
         buttons.register_buttons([self.home_pin], self.home_callback)
 
-        if self.enable_sensors_in_gui:
-            if self.home_pin is not None:
-                self.home_filament_switch_name = "filament_switch_sensor {}_home_pin".format(self.name)
-                self.home_sensor = add_filament_switch(self.home_filament_switch_name, self.home_pin, self.printer )
+        if self.home_pin is not None:
+            self.home_sensor = add_filament_switch(f"{self.name}_home_pin", self.home_pin, self.printer, self.enable_sensors_in_gui )
 
     def handle_connect(self):
         """

--- a/AFC-Klipper-Add-On/extras/AFC_buffer.py
+++ b/AFC-Klipper-Add-On/extras/AFC_buffer.py
@@ -57,12 +57,11 @@ class AFCTrigger:
         self.multiplier_high    = config.getfloat("multiplier_high", default=1.1, minval=1.0)
         self.multiplier_low     = config.getfloat("multiplier_low", default=0.9, minval=0.0, maxval=1.0)
 
-        if self.enable_sensors_in_gui:
-            self.adv_filament_switch_name = "filament_switch_sensor {}_{}".format(self.name, "expanded")
-            self.fila_avd = add_filament_switch(self.adv_filament_switch_name, self.advance_pin, self.printer )
+        self.adv_filament_switch_name = "{}_{}".format(self.name, "expanded")
+        self.fila_avd = add_filament_switch(self.adv_filament_switch_name, self.advance_pin, self.printer, show_sensor=self.enable_sensors_in_gui )
 
-            self.trail_filament_switch_name = "filament_switch_sensor {}_{}".format(self.name, "compressed")
-            self.fila_trail = add_filament_switch(self.trail_filament_switch_name, self.trailing_pin, self.printer )
+        self.trail_filament_switch_name = "{}_{}".format(self.name, "compressed")
+        self.fila_trail = add_filament_switch(self.trail_filament_switch_name, self.trailing_pin, self.printer, show_sensor=self.enable_sensors_in_gui )
 
         self.printer.register_event_handler("klippy:ready", self._handle_ready)
 

--- a/AFC-Klipper-Add-On/extras/AFC_extruder.py
+++ b/AFC-Klipper-Add-On/extras/AFC_extruder.py
@@ -20,6 +20,7 @@ class AFCExtruder:
         self.afc        = self.printer.lookup_object('AFC')
         self.gcode      = self.printer.lookup_object('gcode')
         self.logger     = self.afc.logger
+        self.reactor    = None
         self.printer.register_event_handler("klippy:connect", self.handle_connect)
 
         self.toolhead_extruder          = None
@@ -34,7 +35,9 @@ class AFCExtruder:
         self.tool_unload_speed          = config.getfloat("tool_unload_speed", 25)                                      # Unload speed in mm/s when unloading toolhead. Default is 25mm/s.
         self.tool_load_speed            = config.getfloat("tool_load_speed", 25)                                        # Load speed in mm/s when loading toolhead. Default is 25mm/s.
         self.buffer_name                = config.get('buffer', None)                                                    # Buffer to use for extruder, this variable can be overridden per lane
-        self.enable_sensors_in_gui      = config.getboolean("enable_sensors_in_gui", self.afc.enable_sensors_in_gui)    # Set to True toolhead sensors switches as filament sensors in mainsail/fluidd gui, overrides value set in AFC.cfg
+        self.enable_sensors_in_gui      = config.getboolean("enable_sensors_in_gui",    self.afc.enable_sensors_in_gui) # Set to True toolhead sensors switches as filament sensors in mainsail/fluidd gui, overrides value set in AFC.cfg
+        self.enable_runout              = config.getboolean("enable_tool_runout",       self.afc.enable_tool_runout)
+        self.debounce_delay             = config.getfloat("debounce_delay",             self.afc.debounce_delay)
         self.deadband                   = config.getfloat("deadband", 2)                                                # Deadband for extruder heater, default is 2 degrees Celsius
 
         self.lane_loaded                = None
@@ -45,18 +48,17 @@ class AFCExtruder:
             if self.tool_start == "buffer":
                 self.logger.info("Setting up as buffer")
             else:
-                self.tool_start_state = False
                 buttons.register_buttons([self.tool_start], self.tool_start_callback)
-                if self.enable_sensors_in_gui:
-                    self.tool_start_filament_switch_name = "filament_switch_sensor {}".format("tool_start")
-                    self.fila_tool_start = add_filament_switch(self.tool_start_filament_switch_name, self.tool_start, self.printer )
+                self.fila_tool_start, self.debounce_button_start = add_filament_switch("tool_start", self.tool_start, self.printer,
+                                                                                        self.enable_sensors_in_gui, self.handle_start_runout, self.enable_runout,
+                                                                                        self.debounce_delay )
 
         self.tool_end_state = False
         if self.tool_end is not None:
             buttons.register_buttons([self.tool_end], self.tool_end_callback)
-            if self.enable_sensors_in_gui:
-                self.tool_end_state_filament_switch_name = "filament_switch_sensor {}".format("tool_end")
-                self.fila_avd = add_filament_switch(self.tool_end_state_filament_switch_name, self.tool_end, self.printer )
+            self.fila_tool_end, self.debounce_button_end = add_filament_switch("tool_end", self.tool_end, self.printer,
+                                                                                self.enable_sensors_in_gui, self.handle_end_runout, self.enable_runout,
+                                                                                self.debounce_delay )
 
         self.common_save_msg = "\nRun SAVE_EXTRUDER_VALUES EXTRUDER={} once done to update values in config".format(self.name)
 
@@ -100,6 +102,20 @@ class AFCExtruder:
             if hasattr(lane, "handle_toolhead_runout"):
                 lane.handle_toolhead_runout(sensor=sensor_name)
 
+    def handle_start_runout( self, eventtime):
+        """
+        Callback function for tool start runout, this is different than `tool_start_callback` function as this function
+        can be delayed and is called from filament_switch_sensor class when it detects a runout event.
+
+        Before exiting `min_event_systime` is updated as this mimics how its done in `_exec_gcode` function in RunoutHelper class
+        as AFC overrides `_runout_event_handler` function with this function callback. If `min_event_systime` does not get
+        updated then future switch changes will not be detected.
+
+        :param eventtime: Event time from the button press
+        """
+        self._handle_toolhead_sensor_runout(self.fila_tool_start.runout_helper.filament_present, "tool_start")
+        self.fila_tool_start.runout_helper.min_event_systime = self.reactor.monotonic() + self.fila_tool_start.runout_helper.event_delay
+
     def tool_start_callback(self, eventtime, state):
         """
         Callback for the tool_start (pre-extruder) filament sensor.
@@ -108,20 +124,31 @@ class AFCExtruder:
         :param state: Boolean indicating sensor state (True = filament present, False = runout)
         """
         self.tool_start_state = state
-        self._handle_toolhead_sensor_runout(state, "tool_start")
 
     def buffer_trailing_callback(self, eventtime, state):
         self.buffer_trailing = state
 
+    def handle_end_runout( self, eventtime):
+        """
+        Callback function for tool end runout, this is different than `tool_end_callback` function as this function
+        can be delayed and is called from filament_switch_sensor class when it detects a runout event.
+
+        Before exiting `min_event_systime` is updated as this mimics how its done in `_exec_gcode` function in RunoutHelper class
+        as AFC overrides `_runout_event_handler` function with this function callback. If `min_event_systime` does not get
+        updated then future switch changes will not be detected.
+
+        :param eventtime: Event time from the button press
+        """
+        self._handle_toolhead_sensor_runout(self.fila_tool_end.runout_helper.filament_present, "tool_end")
+        self.fila_tool_end.runout_helper.min_event_systime = self.reactor.monotonic() + self.fila_tool_end.runout_helper.event_delay
+
     def tool_end_callback(self, eventtime, state):
         """
         Callback for the tool_end (post-extruder) filament sensor.
-        Updates the sensor state and triggers runout handling if filament is missing.
+        Updates the sensor state when the button changes state.
         :param eventtime: Event time from the button press
         :param state: Boolean indicating sensor state (True = filament present, False = runout)
         """
-        self.tool_end_state = state
-        self._handle_toolhead_sensor_runout(state, "tool_end")
         self.tool_end_state = state
 
     def get_heater(self):

--- a/AFC-Klipper-Add-On/extras/AFC_hub.py
+++ b/AFC-Klipper-Add-On/extras/AFC_hub.py
@@ -15,11 +15,13 @@ except: raise error(ERROR_STR.format(import_lib="AFC_utils", trace=traceback.for
 
 class afc_hub:
     def __init__(self, config):
-        self.printer = config.get_printer()
+        self.printer    = config.get_printer()
         self.printer.register_event_handler("klippy:connect", self.handle_connect)
-        self.afc = self.printer.lookup_object('AFC')
-        self.fullname           = config.get_name()
-        self.name               = self.fullname.split()[-1]
+        self.afc        = self.printer.lookup_object('AFC')
+        self.reactor    = self.printer.get_reactor()
+
+        self.fullname   = config.get_name()
+        self.name       = self.fullname.split()[-1]
 
         self.unit = None
         self.lanes = {}
@@ -47,7 +49,9 @@ class afc_hub:
 
         self.config_bowden_length   = self.afc_bowden_length                        # Used by SET_BOWDEN_LENGTH macro
         self.config_unload_bowden_length = self.afc_unload_bowden_length
-        self.enable_sensors_in_gui  = config.getboolean("enable_sensors_in_gui", self.afc.enable_sensors_in_gui) # Set to True to show hub sensor switche as filament sensor in mainsail/fluidd gui, overrides value set in AFC.cfg
+        self.enable_sensors_in_gui  = config.getboolean("enable_sensors_in_gui",    self.afc.enable_sensors_in_gui) # Set to True to show hub sensor switche as filament sensor in mainsail/fluidd gui, overrides value set in AFC.cfg
+        self.debounce_delay         = config.getfloat("debounce_delay",             self.afc.debounce_delay)
+        self.enable_runout          = config.getboolean("enable_hub_runout",        self.afc.enable_hub_runout)
 
         buttons = self.printer.load_object(config, "buttons")
         if self.switch_pin in (None, "None", ""):
@@ -58,16 +62,33 @@ class afc_hub:
         self.state = False
         buttons.register_buttons([self.switch_pin], self.switch_pin_callback)
 
-
-        if self.enable_sensors_in_gui:
-            self.filament_switch_name = "filament_switch_sensor {}_Hub".format(self.name)
-            self.fila = add_filament_switch(self.filament_switch_name, self.switch_pin, self.printer )
+        self.fila, self.debounce_button = add_filament_switch( f"{self.name}_Hub", self.switch_pin, self.printer,
+                                                                self.enable_sensors_in_gui, self.handle_runout, self.enable_runout,
+                                                                self.debounce_delay)
 
         # Adding self to AFC hubs
         self.afc.hubs[self.name]=self
 
     def __str__(self):
         return self.name
+
+    def handle_runout(self, eventtime):
+        """
+        Callback function for hub runout, this is different than `switch_pin_callback` function as this function
+        can be delayed and is called from filament_switch_sensor class when it detects a runout event.
+
+        Before exiting `min_event_systime` is updated as this mimics how its done in `_exec_gcode` function in RunoutHelper class
+        as AFC overrides `_runout_event_handler` function with this function callback. If `min_event_systime` does not get
+        updated then future switch changes will not be detected.
+
+        :param eventtime: Event time from the button press
+        """
+        # Only trigger runout for the currently loaded lane (in the toolhead) if it belongs to this hub
+        current_lane_name = getattr(self.afc, 'current', None)
+        if current_lane_name and current_lane_name in self.lanes:
+            lane = self.lanes[current_lane_name]
+            lane.handle_hub_runout(sensor=self.name)
+        self.fila.runout_helper.min_event_systime = self.reactor.monotonic() + self.fila.runout_helper.event_delay
 
     def handle_connect(self):
         """
@@ -82,11 +103,6 @@ class afc_hub:
 
     def switch_pin_callback(self, eventtime, state):
         self.state = state
-        # Only trigger runout for the currently loaded lane (in the toolhead) if it belongs to this hub
-        current_lane_name = getattr(self.afc, 'current', None)
-        if current_lane_name and current_lane_name in self.lanes:
-            lane = self.lanes[current_lane_name]
-            lane.handle_hub_runout(sensor=self.name)
 
     def hub_cut(self, cur_lane):
         servo_string = 'SET_SERVO SERVO={servo} ANGLE={{angle}}'.format(servo=self.cut_servo_name)

--- a/AFC-Klipper-Add-On/extras/AFC_lane.py
+++ b/AFC-Klipper-Add-On/extras/AFC_lane.py
@@ -126,7 +126,9 @@ class AFCLane:
         self.park_dist          = config.getfloat('park_dist', 10)                      # Currently unused
 
         self.load_to_hub        = config.getboolean("load_to_hub", self.afc.load_to_hub) # Fast loads filament to hub when inserted, set to False to disable. Setting here overrides global setting in AFC.cfg
-        self.enable_sensors_in_gui  = config.getboolean("enable_sensors_in_gui", self.afc.enable_sensors_in_gui) # Set to True to show prep and load sensors switches as filament sensors in mainsail/fluidd gui, overrides value set in AFC.cfg
+        self.enable_sensors_in_gui  = config.getboolean("enable_sensors_in_gui",    self.afc.enable_sensors_in_gui) # Set to True to show prep and load sensors switches as filament sensors in mainsail/fluidd gui, overrides value set in AFC.cfg
+        self.debounce_delay         = config.getfloat("debounce_delay",             self.afc.debounce_delay)
+        self.enable_runout          = config.getboolean("enable_hub_runout",        self.afc.enable_hub_runout)
         self.sensor_to_show         = config.get("sensor_to_show", None)                # Set to prep to only show prep sensor, set to load to only show load sensor. Do not add if you want both prep and load sensors to show in web gui
 
         self.assisted_unload = config.getboolean("assisted_unload", None) # If True, the unload retract is assisted to prevent loose windings, especially on full spools. This can prevent loops from slipping off the spool. Setting value here overrides values set in unit(AFC_BoxTurtle/NightOwl/etc) section
@@ -166,14 +168,26 @@ class AFCLane:
         # Defaulting to false so that extruder motors to not move until PREP has been called
         self._afc_prep_done = False
 
-        if self.enable_sensors_in_gui:
-            if self.prep is not None and (self.sensor_to_show is None or self.sensor_to_show == 'prep'):
-                self.prep_filament_switch_name = "filament_switch_sensor {}_prep".format(self.name)
-                self.fila_prep = add_filament_switch(self.prep_filament_switch_name, self.prep, self.printer )
+        if self.prep is not None:
+            show_sensor = True
+            if not self.enable_sensors_in_gui or (self.sensor_to_show is not None and 'prep' not in self.sensor_to_show):
+                show_sensor = False
+            self.fila_prep, self.prep_debounce_button = add_filament_switch(f"{self.name}_prep", self.prep, self.printer,
+                                                                            show_sensor, enable_runout=self.enable_runout,
+                                                                            debounce_delay=self.debounce_delay )
+            self.prep_debounce_button.button_action = self.handle_prep_runout
+            self.prep_debounce_button.debounce_delay = 0 # Delay will be set once klipper is ready
 
-            if self.load is not None and (self.sensor_to_show is None or self.sensor_to_show == 'load'):
-                self.load_filament_switch_name = "filament_switch_sensor {}_load".format(self.name)
-                self.fila_load = add_filament_switch(self.load_filament_switch_name, self.load, self.printer )
+        if self.load is not None:
+            show_sensor = True
+            if not self.enable_sensors_in_gui or (self.sensor_to_show is not None and 'load' not in self.sensor_to_show):
+                show_sensor = False
+            self.fila_load, self.load_debounce_button = add_filament_switch(f"{self.name}_load", self.load, self.printer,
+                                                                            show_sensor, enable_runout=self.enable_runout,
+                                                                            debounce_delay=self.debounce_delay )
+            self.load_debounce_button.button_action = self.handle_load_runout
+            self.load_debounce_button.debounce_delay = 0 # Delay will be set once klipper is ready
+
         self.connect_done = False
         self.prep_active = False
         self.last_prep_time = 0
@@ -224,6 +238,12 @@ class AFCLane:
             if led is None:
                 raise error(error_string)
         self.espooler.handle_ready()
+
+        # Setting debounce delay after ready so that callback does not get triggered when initially loading
+        if hasattr(self, "prep_debounce_button"):
+            self.prep_debounce_button.debounce_delay = self.debounce_delay
+        if hasattr(self, "load_debounce_button"):
+            self.load_debounce_button.debounce_delay = self.debounce_delay
 
     def handle_moonraker_connect(self):
         """
@@ -423,7 +443,6 @@ class AFCLane:
         else:
             return self.dist_hub_move_speed, self.dist_hub_move_accel
 
-
     def move(self, distance, speed, accel, assist_active=False):
         """
         Move the specified lane a given distance with specified speed and acceleration.
@@ -524,13 +543,34 @@ class AFCLane:
         if self.printer.state_message == 'Printer is ready' and self.unit_obj.type == "HTLF":
             self.prep_state = state
 
-            if self.load_state:
+    def handle_load_runout(self, eventtime, load_state):
+        """
+        Callback function for load switch runout/loading for HTLF, this is different than `load_callback`
+        function as this function can be delayed and is called from filament_switch_sensor class when it detects a runout event.
+
+        Before exiting `min_event_systime` is updated as this mimics how its done in `_exec_gcode` function in RunoutHelper class
+        as AFC overrides `_runout_event_handler` function with this function callback. If `min_event_systime` does not get
+        updated then future switch changes will not be detected.
+
+        :param eventtime: Event time from the button press
+        """
+        # Call filament sensor callback so that state is registered
+        try:
+            self.load_debounce_button._old_note_filament_present(load_state)
+        except:
+            self.load_debounce_button._old_note_filament_present(eventtime, load_state)
+
+        if self.printer.state_message == 'Printer is ready' and self.unit_obj.type == "HTLF":
+            if load_state:
                 self.status = AFCLaneState.LOADED
                 self.unit_obj.lane_loaded(self)
                 self.material = self.afc.default_material_type
                 self.weight = 1000 # Defaulting weight to 1000 upon load
             else:
-                if self.unit_obj.check_runout(self):
+                # Don't run if user disabled sensor in gui
+                if not self.fila_load.runout_helper.sensor_enabled and self.afc.function.is_printing():
+                    self.logger.warning("Load runout has been detected, but pause and runout detection has been disabled")
+                elif self.unit_obj.check_runout(self):
                     # Checking to make sure runout_lane is set
                     if self.runout_lane is not None:
                         self._perform_infinite_runout()
@@ -542,7 +582,6 @@ class AFCLane:
                     self.loaded_to_hub = False
                     self.afc.spool._clear_values(self)
                     self.afc.function.afc_led(self.afc.led_not_ready, self.led_index)
-
         self.afc.save_vars()
 
     def prep_callback(self, eventtime, state):
@@ -609,16 +648,8 @@ class AFCLane:
                         self.status = AFCLaneState.LOADED
                         self.unit_obj.lane_loaded(self)
                         self.afc.spool._set_values(self)
-
-                elif self.prep_state == False and self.name == self.afc.current and self.afc.function.is_printing() and self.load_state and self.status != AFCLaneState.EJECTING:
-                    # Checking to make sure runout_lane is set
-                    if self.runout_lane is not None:
-                        self._perform_infinite_runout()
-                    else:
-                        self._perform_pause_runout()
-
                 elif self.prep_state == True and self.load_state == True and not self.afc.function.is_printing():
-                    if self.unit_obj.type == "AMS":
+                    if getattr(self.unit_obj, "type", None) == "AMS":
                         self.status = AFCLaneState.LOADED
                         self.unit_obj.lane_loaded(self)
                         self.afc.spool._set_values(self)
@@ -632,8 +663,43 @@ class AFCLane:
                     self.loaded_to_hub = False
                     self.afc.spool._clear_values(self)
                     self.unit_obj.lane_unloaded(self)
-
         self.prep_active = False
+        self.afc.save_vars()
+
+    def handle_prep_runout(self, eventtime, prep_state):
+        """
+        Callback function for prep switch runout, this is different than `prep_callback`
+        function as this function can be delayed and is called from filament_switch_sensor class when it detects a runout event.
+
+        Before exiting `min_event_systime` is updated as this mimics how its done in `_exec_gcode` function in RunoutHelper class
+        as AFC overrides `_runout_event_handler` function with this function callback. If `min_event_systime` does not get
+        updated then future switch changes will not be detected.
+
+        :param eventtime: Event time from the button press
+        """
+        # Call filament sensor callback so that state is registered
+        try:
+            self.prep_debounce_button._old_note_filament_present(prep_state)
+        except:
+            self.prep_debounce_button._old_note_filament_present(eventtime, prep_state)
+
+        if self.printer.state_message == 'Printer is ready' and True == self._afc_prep_done and self.status != AFCLaneState.TOOL_UNLOADING:
+            if prep_state == False and self.name == self.afc.current and self.afc.function.is_printing() and self.load_state and self.status != AFCLaneState.EJECTING:
+                # Don't run if user disabled sensor in gui
+                if not self.fila_prep.runout_helper.sensor_enabled:
+                    self.logger.warning("Prep runout has been detected, but pause and runout detection has been disabled")
+                # Checking to make sure runout_lane is set
+                elif self.runout_lane is not None:
+                    self._perform_infinite_runout()
+                else:
+                    self._perform_pause_runout()
+            elif not prep_state:
+                # Filament is unloaded
+                self.status = AFCLaneState.NONE
+                self.loaded_to_hub = False
+                self.afc.spool._clear_values(self)
+                self.unit_obj.lane_unloaded(self)
+
         self.afc.save_vars()
 
     def do_enable(self, enable):

--- a/AFC-Klipper-Add-On/extras/AFC_utils.py
+++ b/AFC-Klipper-Add-On/extras/AFC_utils.py
@@ -7,6 +7,7 @@
 # File is used to hold common functions that can be called from anywhere and don't belong to a class
 import traceback
 import json
+import inspect
 
 from datetime import datetime
 from urllib.request import (
@@ -21,7 +22,7 @@ from urllib.parse import (
 
 ERROR_STR = "Error trying to import {import_lib}, please rerun install-afc.sh script in your AFC-Klipper-Add-On directory then restart klipper\n\n{trace}"
 
-def add_filament_switch( switch_name, switch_pin, printer ):
+def add_filament_switch( switch_name, switch_pin, printer, show_sensor=True, runout_callback = None, enable_runout=False, debounce_delay=0. ):
     """
     Helper function to register pins as filament switch sensor so it will show up in web guis
 
@@ -33,18 +34,41 @@ def add_filament_switch( switch_name, switch_pin, printer ):
     """
     import configparser
     import configfile
+    new_switch_name = f"filament_switch_sensor {switch_name}"
     ppins = printer.lookup_object('pins')
     ppins.allow_multi_use_pin(switch_pin.strip("!^"))
     filament_switch_config = configparser.RawConfigParser()
-    filament_switch_config.add_section( switch_name )
-    filament_switch_config.set( switch_name, 'switch_pin', switch_pin)
-    filament_switch_config.set( switch_name, 'pause_on_runout', 'False')
+    filament_switch_config.add_section( new_switch_name )
+    filament_switch_config.set( new_switch_name, 'switch_pin', switch_pin)
+    filament_switch_config.set( new_switch_name, 'pause_on_runout', 'False')
+    filament_switch_config.set( new_switch_name, 'debounce_delay', 0.0)
 
-    cfg_wrap = configfile.ConfigWrapper( printer, filament_switch_config, {}, switch_name)
+    cfg_wrap = configfile.ConfigWrapper( printer, filament_switch_config, {}, new_switch_name)
 
-    fila = printer.load_object(cfg_wrap, switch_name)
-    fila.runout_helper.sensor_enabled = False
-    fila.runout_helper.runout_pause = False
+    fila = printer.load_object(cfg_wrap, new_switch_name)
+
+    # Commence the hacky stuff for delayed runout
+    if not show_sensor:
+        # Removing normal switch name from object and adding name with underscore if user does not want
+        # sensor showing up in gui. Doing this suppressed the sensor from showing up in gui  since the
+        # name is not exactly "filament_switch_sensor"
+        printer.objects["_" + new_switch_name] = printer.objects.pop(new_switch_name)
+
+    fila.runout_helper.sensor_enabled = enable_runout
+    fila.runout_helper.runout_pause = False                 # AFC will deal with pause
+
+    filament_switch_config.set( new_switch_name, 'debounce_delay', debounce_delay)
+    # Using our own DebounceButton so that callback functions can be overridden to work correctly
+    debounce_button = DebounceButton(cfg_wrap, fila)
+
+    if runout_callback:
+        #fila.runout_helper.event_delay = 0.0                # Setting event delay to zero or total delay will be event_delay + debounce_delay
+        fila.runout_helper.insert_gcode = None
+        fila.runout_helper.runout_gcode = 1
+        fila.runout_helper._runout_event_handler = runout_callback # Overriding filament event handler with AFC handler
+
+    if enable_runout:
+        return fila, debounce_button
 
     return fila
 
@@ -62,6 +86,55 @@ def check_and_return( value_str:str, data_values:dict ) -> str:
         value = data_values[value_str]
 
     return value
+
+# Copied from klipper for kalico and older klipper support
+class DebounceButton:
+    def __init__(self, config, filament_sensor):
+        self.printer = config.get_printer()
+        self.reactor = self.printer.get_reactor()
+        sig = inspect.signature(filament_sensor.runout_helper.note_filament_present)
+        # Saving reference to normal function
+        self._old_note_filament_present = filament_sensor.runout_helper.note_filament_present
+        # Setting action callback to normal filament sensor not filament present
+        self.button_action = self._old_note_filament_present
+        # Overriding filament sensor filament present to button handler in this class
+        # Checking parameter length since kalico's note_filament_present function is different
+        if len(sig.parameters) > 2:
+            filament_sensor.runout_helper.note_filament_present = self.button_handler
+        else:
+            filament_sensor.runout_helper.note_filament_present = self._button_handler
+        self.debounce_delay = config.getfloat('debounce_delay', 0., minval=0.)
+        self.logical_state = None
+        self.physical_state = None
+        self.latest_eventtime = None
+
+    def button_handler(self, state):
+        self._button_handler(self.reactor.monotonic(), state)
+
+    def _button_handler(self, eventtime, state):
+        self.physical_state = state
+        self.latest_eventtime = eventtime
+        # if there would be no state transition, ignore the event:
+        if self.logical_state == self.physical_state:
+            return
+        trigger_time = eventtime + self.debounce_delay
+        self.reactor.register_callback(self._debounce_event, trigger_time)
+
+    def _debounce_event(self, eventtime):
+        # if there would be no state transition, ignore the event:
+        if self.logical_state == self.physical_state:
+            return
+        # if there were more recent events, they supersede this one:
+        if (eventtime - self.debounce_delay) < self.latest_eventtime:
+            return
+        # enact state transition and trigger action
+        self.logical_state = self.physical_state
+        # Kalico is different from klipper and eventtime is not passed in
+        try:
+            self.button_action(self.logical_state)
+        except:
+            self.button_action(eventtime, self.logical_state)
+
 
 class AFC_moonraker:
     """

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,936 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [2025-08-22]
+### Added
+- Added a new command to test lane loading and unloading in an automated and random fashion (`AFC_TEST_LANES`). Please
+  see the documentation for more information on how to use this command and it's various options.
+- Option to delay/debounce switches. Debounce delay is defaulted to zero but can be updated globally by adding `debounce_delay: <delay_value>`
+  to AFC config section. Or this value can be added per AFC_extruder, AFC_hub, AFC_stepper/AFC_lane configs. Runout can be also disabled by
+  turning off filament switch in gui, if PREP sensor is disabled this will also disable infinite spool rollover. When klipper is restarted
+  all switches will be enabled again.
+
+## [2025-08-17]
+### Added
+- Servo option to brush macro.
+
+## [2025-08-10]
+### Fixed
+- A negative `afc_unload_bowden_length` is no longer able to be set by the calibration routine. 
+
+## [2025-08-06]
+### Fixed
+- The `install-afc.sh` script will no longer tell you it removed the `velocity` setting if it didn't exist.
+
+## [2025-07-30]
+### Fixed
+- Updated the `SET_MAP` command to correctly handle `MAP` parameters in either upper or lower case text. 
+
+## [2025-07-27]
+### Updated
+- The `install-afc.sh` script will now only copy relevant MCU files when installing a new unit. 
+
+## [2025-07-20]
+### Added
+- Software defined physical buttons are now available and supported. See documentation for more information on how to set them up.
+- New command `SET_NEXT_SPOOL_ID` to be used with a QR scanner tool or macro that automatically sets the id of the next spool loaded.
+- Support setting tool_max_unload_attempts to zero to bypass buffer unloading checks
+
+## [2025-07-19]
+### Fixes
+- Error with infinite spool where klipper would crash if runout was set to `None` instead of `"NONE"`
+- Added a check when enabling virtual bypass to make sure a lane is not loaded when enabling.
+- Issue where localhost and http were hardcoded, allows user to specify custom url. Fixes issue 484.
+- Updated code to inform users when trying to assign spoolman ID to a lane and that same spool ID is already assigned to another lane.
+
+## [2025-07-06]
+### Fixes
+- Race condition between klipper and moonraker when trying to get stats from moonraker database
+
+## [2025-06-30]
+### Fixes
+- Issue #476 where turn off led macro didn't turn off LEDs while printing
+- TTC's that some users were having that was induced by commit `1201bcc`
+
+## [2025-06-28]
+### Updated
+- The `install-afc.sh` script will now display the version when an update is completed.
+
+## [2025-06-23]
+### Added
+- Runout/break/jam detection for hub and toolhead sensors:
+- If the toolhead or hub sensor detects runout but upstream sensors still detect filament, the print is paused and the user is notified of a possible break/jam (no eject or endless spool mode is attempted).
+- Runout/pause logic only triggers during normal printing states, preventing false positives during lane load/unload or filament swaps.
+- `handle_toolhead_runout` and `handle_hub_runout` methods added to `AFCLane` for special handling of break/jam scenarios at the toolhead and hub.
+- Hub sensor callback now calls `handle_hub_runout` on all associated lanes when runout is detected.
+
+### Changed
+- Enhanced runout logic in `AFC_lane.py`, `AFC_extruder.py`, and `AFC_hub.py` to support multi-sensor and break/jam detection.
+
+### Fixed
+- Addresses issue [#389](https://github.com/ArmoredTurtle/AFC-Klipper-Add-On/issues/389) and [#387](https://github.com/ArmoredTurtle/AFC-Klipper-Add-On/issues/387)
+- Added cutting direction check to _MOVE_TO_CUTTER_PIN. This prevents crashes when using front/back cutting motion.
+
+## [2025-06-21]
+### Fixed
+- Ensure `default_material_temps` name matching in temperature selection logic is case-insensitive.
+
+## [2025-06-19]
+## Updated
+- The `afc-debug.sh` script will now also include the `moonraker.conf` file if it is present.
+
+### Added
+- Added an option to disable skew_correction for kinematic moves.
+- AFC now errors out when using buffer as toolhead sensor and it fails to decompress when loading/unloading.
+
+## [2025-06-18]
+## Updated
+- RESET_AFC_MAPPING function to reset manually set lane mapping in config to correct lane
+
+## Fixed
+- Fixed function that auto assigns T(n) commands to check and verify that other T(n) commands are not already registered outside of AFC
+
+## [2025-06-17]
+### Fixed
+- Updated `cycles_per_rotation` value to be less aggressive at 800 for print assist
+- Updated `enable_assist_weight` value to be 500 so print assist start once weight gets below 500 grams
+
+## [2025-06-16]
+### Removed
+- Removed the version checking functionality for force updates from the `install-afc.sh` script. 
+
+### Fixed
+- Issue where espoolers would move way faster than normal when weight was below empty spool weight.
+
+## [2025-06-15]
+### Added
+- Added support for the AFC-Pro board in the installer to install an 8-Lane Boxturtle.
+- The `RESET_AFC_MAPPING` macro will now also reset any runout lane configurations.
+
+## [2025-06-10]
+### Added
+- Ability to turn on print assist if spool falls below a certain weight
+- Weight defaults to 1kg when first inserting spool
+- `AFC_CLEAR_MESSAGE` macro to clear current message that would be displayed in gui's
+- When saving variables and key is not found in current AFC files, a new file `AFC_auto_vars.cfg` will be created and variables will be added to that file
+
+## [2025-06-08]
+### Added
+- Support for [QuattroBox](https://github.com/Batalhoti/QuattroBox) filament changer. QuattroBox can be chosen in install script for new or additional units to add to your printer
+
+## [2025-06-07]
+### Fixed
+- `unknown command: Prompt_end` error will no longer show when users try to exit out of Happy Printing popup after AFC_CALIBRATION is done
+- Lanes are now marked a loaded_to_hub when bowden calibration happens
+- Fixed issue where HTLF might error out when first homing during PREP
+
+## [2025-06-06]
+### Added
+- There is now a configurable option `error_timeout` in the `[AFC]` section of the `AFC.cfg` file. This option allows 
+users to set a timeout for how long the printer will stay in a paused state when an error occurs. The default value is 
+`36000` seconds (10 hours). When a `PAUSE` action is triggered, AFC will now compare the value of the `error_timeout` and
+the `idle_timeout` value (if defined) and choose the larger of the two values. 
+
+### Changed
+- The `afc-debug.sh` script will now create a zip file of the logs if the `nc` utility is not available. 
+
+
+## [2025-05-30]
+### Added
+- Updated park to allow moving to an absolute z height after the x,y move. This is intended to reduce oozing during unload and load prior to using the poop command.
+
+## [2025-05-29]
+### Fixed
+- HTLF infinite runout now works correctly
+
+## [2025-05-27]
+### Added
+- Some AFC macros are now exposed in Mainsail/Fluidd. 
+
+## [2025-05-25]
+### Fixed
+- Exclude object bug where klipper would error out with max extrude error after excluding an object and 
+  trying to do a lane swap or doing TOOL_UNLOAD in PRINT_END function. Fixes issue [#364](https://github.com/ArmoredTurtle/AFC-Klipper-Add-On/issues/364)
+- Fixing issue [#348](https://github.com/ArmoredTurtle/AFC-Klipper-Add-On/issues/348)
+
+## [2025-05-24]
+### Fixed
+- The calibration routines will now not allow a negative bowden length value to be set. If a negative value is detected, 
+an error message will be displayed and the value will not be set.
+
+## [2025-05-23]
+### Updated
+- The `PREP` sequence will now check to ensure the trailing and advance buffer switches are not both triggered. If 
+  both switches are triggered, a warning message will be displayed.
+
+## [2025-05-22]
+### Added
+- Added `auto_home` support,
+
+## [2025-05-22]
+### Added
+- Added statistics tracking for tool load/unload/total change, n20 runtime, number of cuts,
+  average load/unload/full toolchange times, and number of load per lane.
+- Added ability to track when last blade was changed and how many cuts since last changed
+- `AFC_STATS` macro added to print statistics out. Set `SHORT=1` to print out a skinny version
+- `AFC_CHANGE_BLADE` macro added for when users change blade as this reset count and updates date changed
+- `AFC_RESET_MOTOR_TIME` macro added to allow users to reset N20 active time if motor was replaced in a lane
+- Added common class for easily interacting with moonraker api
+- Updated to use moonrakers proxy when fetching spoolmans data
+- Added getting toolchange count from moonrakers file metadata, `SET_AFC_TOOLCHANGES` will be deprecated
+  Moonrakers version needs to be at least v0.9.3-64
+- Updated import error message to pull from a common error string in AFC_utils.py file
+- Clearing pause in klipper when starting a print
+- Warning message is outputted when number of cuts is within 1K of tool_cut_threshold value
+- Error message is outputted when number of cuts is over tool_cut_threshold
+
+### Fixed
+- Issue where virtual bypass was being set for newly installed instances of AFC
+
+## [2025-05-21]
+### Added
+- new macro `AFC_TOGGLE_MACRO` to enable disable other macros.
+
+## [2025-05-15]
+### Added
+- added quiet mode support. `quiet_moves_speed` on `AFC.cfg` dictates the max speed when quiet mode is enabled.
+- new macro `AFC_QUIET_MODE ENABLE=1/0 SPEED=<max_speed>` to allow modifying `quiet_moves_speed` and enable/disable quiet mode.
+
+## [2025-05-12]
+### Added
+- new variable `tool_homing_distance` in `[AFC]` to make the distance over which toolhead homing is attempted.
+- new variable `rev_long_moves_speed_factor` added to `AFC_lane` to allow per lane reverse speed for long moves. i.e. long move speeds will now be `rev_long_moves_speed_factor * long_move_speed`.
+- new macro `SET_LONG_MOVE_SPEED LANE=<lane_name> FWD_SPEED=<fwd_speed> RWD_FACTOR=<rwd_multiplier> SAVE=1/0` to allow modifying `rev_long_moves_speed_factor` and `long_move_speed`
+
+
+## [2025-05-11]
+### Changed
+- The `install-afc.sh` script will remove any `velocity` settings present in the `[AFC_buffer <buffer_name>]` 
+  section of the configuration files as they are no longer needed.
+
+## [2025-05-01]
+### Added
+- Print assist is now filament usage based and will activate spool after a specified amount of filament is used. This is enabled by default.
+
+### Removed
+- Removed velocity from AFC_buffer code and install code, please remove `velocity`  variable from AFC_buffer configuration
+
+## [2025-04-27]
+
+### Removed
+- Removed deprecated belay code.
+
+## [2025-04-25]
+### Added
+- The AFC_CUT macro now supports a servo-activated pin. Set values for ``[servo tool_cut]`` in ``AFC_Hardware.cfg`` and enable ``tool_servo_enable`` in ``AFC_Macro_Vars.cfg``
+
+## [2025-04-23]
+
+### Added
+- The `install-afc.sh` script will now prompt you if you want to update the AFC provided macros when updating the 
+  software. **WARNING** This will overwrite any existing macros present. 
+
+## [2025-04-20]
+
+### Changed
+- Updated poop to do z lift based off last position so that toolhead does not smash into large poops.
+- Updated kick to move xy first and then move z so toolhead does not smash into poop.
+
+## [2025-04-19]
+
+### Changed
+- The `Type` parameter in the `AFC_<unit_type>.cfg` file is no longer required.
+
+- The `install-afc.sh` script will now check for updates, and if new updates are present, it will sync and git changes
+and re-run the script automatically.
+
+## [2025-04-12]
+
+### Added
+- The `afc-debug.sh` script will now also upload `AFC.log` files for assistance during troubleshooting.
+
+### Changed
+- All documentation is now available on our website at https://armoredturtle.xyz/docs/.
+
+## [2025-04-09]
+
+### Added
+- Added check in prep to make sure printer is homed when using direct loading
+
+### Fixed
+- For direct loading, fixed logic to use load sensor for unloading and then retract back more
+  to make sure filament was fully out of extruder gears
+- Fixed error where start time was not correctly getting set for direct loads
+- Fixed error where unsyncing lanes for HTLF units was still syncing back
+
+## [2025-04-08]
+
+### Added
+- Function to check if in absolute mode and set absolute if in relative mode since
+  AFC does movement base off being in absolute mode
+- Runout/infinite spool support for HTLF unit type
+  
+### Fixed
+- Fixed error where restore_pos was not calculating base position correctly for extruder,
+  matched how RESTORE_STATE does it
+
+## [2025-04-07]
+
+### Fixed
+- Fixed detection for python version check to appropriately check for both python minor and major version.
+
+## [2025-04-06]
+
+### Fixed
+- Update kick macro to ensure we are in absolute position mode (G90) before doing moves
+
+## [2025-04-06]
+
+### Changed
+- Updated wording for when `TOOL_UNLOAD` fails and filament is still in toolhead. Added instruction for user to run `UNSET_LANE_LOADED` before running the correct `T(n)` macro
+
+### Fixed
+- Issue when user tries to run `TEST` macro and `afc_motor_rwd` is not defined in config. Affects configs that don't use spooler motors.
+
+### Removed
+- Remove documentation for Belay support, it is deprecated and will be fully removed in a future release.
+
+## [2025-04-01]
+
+### Added
+- Support for HTLF
+
+### Fixed
+- Error when user calls TOOL_UNLOAD outside a print and it fails to unload. Fixed error where variable was not set when creating message to printout to console
+
+## [2025-03-30]
+### Fixed
+- The `BT_LANE_MOVE` macro now correctly only accepts positive or negative values for the `distance` parameter.
+
+## [2025-03-29]
+### Added
+- The `install-afc.sh` script now has the ability to rename existing units.
+- The `install-afc.sh` script now has the ability to install NightOwl units. Thanks to @thomasfjen for the contribution.
+- The `install-afc.sh` script now has the ability to help install multiple units.
+
+### Fixed
+- The `install-afc.sh` script now correctly checked for a Python version >= Python 3.8.
+
+## [2025-03-27]
+### Added
+- AWD variable to CUT macro so increased current applies to all X motors
+- Updated cut variable retract to 20 and pushback to 15
+
+### Fixed
+- Resetting `in_toolchange` variable when resuming from failure, fixes problems with returning to correct z hight on the next in_toolchange
+- Fixed issued with `AFC_reset` macro when distance was not supplied macro call would crash klipper
+
+## [2025-03-22]
+### Fixed
+- Fixed possible error if hotend current temp is below current temp. 
+
+## [2025-03-17]
+### Added
+- Added `SET_SPEED_MULTIPLIER` macro to allow user to change fwd/rwd speed multipliers during prints
+- Added `SAVE_SPEED_MULTIPLIER` macro to save updated multiplier to config file for specified lane
+
+### Fixed
+- Added check to AFC pause/resume functions to make sure printer was not paused/paused before doing any actions
+- Fixed issue where macro variables were not passed from AFC_PAUSE/AFC_RESUME to PAUSE/RESUME macros if user passed in variables when calling these macros  
+
+## [2025-03-12]
+### Added
+- Virtual bypass sensor, AFC adds this sensor if hardware bypass is not detected
+
+### Fixed
+- Issue where z would move back down when calling cut macro after z hop from AFC
+
+## [2025-03-10]
+### Added
+- Reporting error messages in AFC status so they can be shown in AFC integration panel
+
+### Fixed
+- Issue where resuming position could crash into object/purge tower
+- Issue where creating filament_switch_sensor in AFC would cause klipper to error out when AFC include is before `[pause_resume]` and user has `recover_velocity` defined
+- Issue where passing in `+-<number>` for length when calling `SET_BOWDEN_LENGTH` would crash klipper 
+
+## [2025-03-07]
+### Added
+- Added variable_z_purge_move to Poop macro. Setting this to False will allow pooping with no z movement
+- Added variable_z_move to brush macro. this value will set a positive Z move at the end of the brush to move the nozzle away from the brush
+
+### Fixed
+- Fixed error that occurs when all lanes are calibrated
+
+## [2025-03-07]
+### Added
+- Added error checking to spool runout, before if a error happened during unload it could keep running the print
+- Added lane ejection when runout detected but rollover not setup
+- Added AFC_PAUSE function to override users pause macro so that necessary measures could be added to move in Z to avoid
+  hitting part if users pause macro moves toolhead
+- Added `afc_unload_bowden_length` parameter
+- Added moving Z to previous saved position +z hop when resuming to avoid hitting part when moving back
+
+### Fixed
+- Fixed error when trying to turn of LEDs
+- Fixed saving position as it was not saving correctly
+- Reworked rollover logic to restore position after lane has been ejected fully so that nozzle does not sit
+  on part while ejecting spool
+- Fixed error where user could put wrong lane for rollover and it would not error until runout logic is triggered
+- Fixed errors found in calibration routines
+
+
+## [2025-03-02]
+
+### Fixed
+- Fixed calibration to error out at excessive distances
+    - Calibration uses default config values plus fixed distances to be able to error out distances
+
+## [2025-02-28]
+
+### Added
+- Logging of delta time and total time for how long toolchanges take
+- Logging for AFC now logs to AFC.log file
+- Ability to turn off/on AFC leds with `TURN_OFF_AFC_LED`/`TURN_ON_AFC_LED`
+- `default_material_type` variable to assign to spool when loaded into lane
+- `pause_when_bypass_active` variable to pause print if bypass is active, defaults to false
+- `unload_on_runout variable` to unload lane when runout happens and another lane is not setup to change to, default to false
+- Updated calibration to use buffer as tool_pin_start if only tool_pin_end is defined and buffer is also defined
+- Ability to change tool_stn/tool_stn_unload/tool_sensor_after_extruder without restarting
+
+### Fixed
+- Issue where filament was not unloading correctly when only tool_pin_end is defined
+- Issue where prep logic would try to unload forever if only tool_pin_end was defined
+
+## [2025-02-25]
+
+### Fixed
+
+- Tip forming was multiplying all speeds with a factor of 60 by mistake. Existing configuration might need to be adapted
+  to compensate for this fix.
+
+## [2025-02-23]
+
+### Added
+- Checking to make sure lane was not None in cmd_CHANGE_TOOL
+- Pauses in TOOL_LOAD/TOOL_UNLOAD/CHANGE_TOOL for early returns if printer is currently in a print
+
+### Changed
+- The `install-afc.sh` script will now check for a supported version of python and fail the installation if it is not present.
+
+### Fixed
+- Error in cmd_CHANGE_TOOL where change logic was being triggered if change was in a comment on the same line
+- Turned runout pause message into error message which also pauses printer
+- Error where infinite spool would crash klipper when calling change tool
+
+## [2025-02-20]
+
+### Added
+
+- Users are now able to specify a non default moonraker address when using the `install-afc.sh` script. This value defaults to `http://localhost` but
+can be adjusted for cases such as a remote moonraker installation, https, etc. This value can be set during the installation process by using the `-a <address>` flag.
+
+## [2025-02-19]
+
+### Added
+- Clearing error_state when print starts, before this could be set before printing and would cause AFC to not save/restore position
+- Added 1 second time debounce to prep callback
+- Added abs function when determining speed for LANE_MOVE macro
+
+### Changed
+- Updated error print out messages when loading/unloading
+- The way error messages printed out so they are grouped together
+
+### Fixed
+- Issue where getting spoolman data would error out when server variable in moonraker ended in a slash
+- Issue where prep would no longer activate extruder motors when user rapidely triggered prep sensor
+
+## [2025-02-17]
+
+### Changed
+- Updated the `install-afc.sh` script to prompt the user to install dependencies if they are not already installed instead of installing them automatically.
+
+## [2025-02-16]
+
+### Added
+- Ability to manually set and unset lanes that are loaded in toolhead
+- Braking to n20 when stopping them. This was advised to implement from Isik to hopefully help reduce backfeeding from motors into MCU board when in coast mode
+- Default temperature value to default_material_temps list instead of using min_temp_val + 5
+- Check for printing for LANE_MOVE, HUB_LOAD and LANE_UNLOAD macros
+- Variable for prep done so save_vars function is not called before running prep function which would override the variables file before PREP could run
+- More guidance to error messages when errors happen during TOOL_LOAD and TOOL_UNLOAD
+- Helper function to get loaded lane for current extruder, help move the code towards working with multiple extruders
+- Debounce logic when triggering prep sensor so that it does not run more than once
+- Variable speed to LANE_MOVE move, run faster for distance over 200
+- Printout when trying to load and load sensor is already triggered
+- More printout to let user know when calibration is done
+- Printout when trying to unload but no lane is loaded
+
+### Changed
+- Updated documentation
+
+### Fixed
+- Error in prep when there are multiple extruders
+- Error when hub was not defined
+
+## [2025-02-13]
+
+### Added
+- Assisted unload  
+  When enabled, the retracts out of the toolhead before the long, fast move back throught the bowden tube is assisted.
+  This helps with full spools where even a retract of a few centimeters can cause a loop to fall off the spool.
+
+### Changed
+- The `install-afc.sh` install script will now remove the `AFC.var.tool` file if detected as it is no longer needed.
+
+## [2025-02-04]
+
+### Changed
+- Changed default `hub_clear_move_dis` to 25 to avoid too much retraction during filament changes
+
+### Fixed
+- Fixed error out during calibration when not calibrating bowden length
+- Fixed issue where AFC could crash klipper in some scenarios when tool unloads fail to clear hub
+
+
+## [2025-02-03]
+
+### Changed
+- Added expanded and compressed to buffer query for easier troubleshooting
+
+### Fixed
+- Corrected readme to point to the correct files
+- Added check for key on bowden length calibration to not crash klipper if the wrong value is provided
+
+## [2025-01-28]
+
+### Changed
+- Added `velocity` default setting back into buffer configuration when using the `install-afc.sh` script. This value was previously set to `0` by default,
+but the configuration did not display this value. For future installations, this value will be explicitly set in the buffer configuration.
+
+### Fixed
+- Added minor documentation changes regarding `velocity` changes in the buffer configuration.
+
+## [2025-01-26]
+### Added
+- Added ability to specify moonraker port, needed for when user has multiple moonraker/klipper instances on a single machine
+
+### Fixed
+- Fixed issue where software was updated to no long detected movement outside of printing, this fixes crashing klipper when inserting filament while printer is moving
+- Fixed issue where remaining weight was not being pulled correctly from spoolman
+
+## [2025-01-23]
+### Fixed
+- Fixed not being able to unload filament with UNLOAD_FILAMENT macro when using bypass
+
+## [2025-01-17]
+### Added
+- Added ability to break up long bowden moves into shorter moves with `max_move_dis` variable to help with users that are facing timer too close issues when doing long moves. This variable can be set in `AFC.cfg` as a global setting or in the stepper/config sections.
+
+### Changed
+- Function `isPrinting` is determined by `print_stats` instead of `idle_timeout`
+- Check extruder temp function only sets temperature if hotend can't extrude(temp below min value) and if printer is not printing, so that hotend temperature is not changed while printing
+
+## [2025-01-12]
+### Added
+
+- Added Guided calibration using `AFC_CALIBRATION`
+  - With the call of `AFC_CALIBRATION` the user will be guided through calibrating the lanes in their AFC unit.
+- Added `UNIT` as an option to the `CALIBRATE_AFC` macro that is leveraged to calibrate lanes in a specific unit.
+
+## [2025-01-12]
+### Added
+- Remapping stock `UNLOAD_FILAMENT` to call `TOOL_UNLOAD` function. Stock `UNLOAD_FILAMENT` will be renamed to `_AFC_RENAMED_UNLOAD_FILAMENT_` and can still be called from the command line. If trying to do a `TOOL_UNLOAD` and filament is loaded into bypass, AFC will unload with `_AFC_RENAMED_UNLOAD_FILAMENT_` macro. Remapping `UNLOAD_FILAMENT` macro can be disabled by setting `disable_unload_filament_remapping: True` in AFC_prep config section. 
+- Added `docs/CONFIGURATION_OPTIONS.md` file that describes the different config parameters, still a work in progress
+
+### Changed
+- AFC-Klipper-Add-On now pulls spoolman ip/port from moonracker.conf file, please remove `spoolman_ip` and `spoolman_port` from `AFC/AFC.cfg` file
+
+
+## [2025-01-11]
+### Added
+- Added clearing spool info and `load_to_hub` when lane retracts too far past Box Turtle extruder, reset once prep goes low
+- Added logic so that buffer/extruder/hubs don't need to be entered per stepper as long as they are defined in their Unit(AFC_BoxTurtle/AFC_NightOwl) section 
+
+For the following please see [Features doc](docs/Features.md) for more information on how to setup
+- Added ability to set and track number of toolchanges when doing multicolor prints
+- Added ability to set extruder temperature based off spoolman values or filament materials type if manually entered
+- Added ability to show sensors as filament sensors in gui's
+- Added ability to use multiple buffers
+- Added automatically loading filament to hub for users that have moved their hubs closer to their toolhead
+
+## [2025-01-10]
+
+### Changed
+- Due to a too long retraction, hub cuts had the risk of ejecting filament from the extruder,
+  requiring manual intervention. The hub cut sequence was changed to avoid this situation.
+
+  **NOTE**: due to the new way hub cuts are performed, the configuration has to be updated!
+        The value `cut_dist` in `[AFC_Hub]` has to be reduced by about 150. Please recalibrate
+        this before the next print.
+
+### Added
+- [AFC_Hub] has a new config option: `assisted_retract`. If set to true, retracts are assisted so
+  that filament can't get loose on the spool.
+
+### Changed
+
+- `http://<ip_address>/printer/objects/query?AFC` has moved to `http://<ip_address>/printer/afc/status`endpoint. If tools have been designed around original endpoint please review results returned as new items have been added
+
+## [2025-01-08]
+### Added
+- If using `tool_end` variable(sensor after extruder gears) `tool_stn` distance will now be based off this sensor
+- When running `CALIBRATE_AFC` command values will be automatically updated and saved to config file
+
+### Fixed
+- Fixed infinite spool logic
+
+## [2025-01-05]
+
+### Updated
+- This update will require the re-installation of an user's configuration  files due to changes in the config file structure.
+- Re-designed the `install-afc.sh` script to be more user-friendly, interactive, and more indicative of what is happening 
+during the installation process.
+
+## [2024-12-29]
+
+### Added
+- **New Command: `GET_TIP_FORMING`**
+  Shows the current tip forming configuration. Mostly interesting together with
+  SET_TIP_FORMING.
+
+- **New Command: `SET_TIP_FORMING`**
+  Allows to update tip forming configuration at runtime.
+
+  See command_reference doc for more info
+
+## [2024-12-23]
+### Added
+- Added ability to set lower stepper current when printing to help reduce how hot steppers can get.
+  To enable this feature set `global_print_current` in AFC.cfg or `print_current` for each AFC_stepper
+  During testing it was found that 0.6 was optimal, going lower than this may result in buffer not working as intended
+
+- Added check to make sure printer is not printing or homing when trying to load a spool. Doing so before would
+  result in klipper crashing.
+
+## [2024-12-22]
+
+### Added
+- **New Command: `SET_BUFFER_VELOCITY`**
+    Allows users to tweak buffer velocity setting while printing. This setting is not
+    saved in configuration.
+
+    See command_reference doc for more info
+
+- **New Command: `TEST_AFC_TIP_FORMING`**
+    Gives ability to test AFC tip forming without doing a tool change
+
+- **New Command: `RESET_AFC_MAPPING`**
+    Resets all tool lane mapping to the order that is setup in configuration
+
+### Fixed
+- Fixed error in tip forming when `toolchange_temp` value is not zero
+
+## [2024-12-20]
+
+### Added
+- More error printouts to aid users
+
+### Fixes
+- Misc error fixes
+
+## [2024-12-13]
+
+### Updated
+- Updated Cut.cfg macro to have the ability to up stepper current when doing filament cutting, 
+  see layer shift troubleshooting section on what values need to be set
+
+## [2024-12-09]
+
+### Added
+- **New Command: `CALIBRATE_AFC`**  
+    Allows calibration of the hub position and Bowden length in the Automated Filament Changer (AFC) system.  
+    Supports calibration for a specific lane or all lanes (`LANE` parameter).  
+    Provides options for distance and tolerance during calibration:
+    - `DISTANCE=<distance>`: Optional distance parameter for lane movement during calibration (default is 25mm).
+    - `TOLERANCE=<tolerance>`: Optional tolerance for fine-tuning adjustments during calibration (default is 5mm).  
+    - Bowden Calibration: Added functionality to calibrate Bowden length for individual lanes using the `BOWDEN` parameter.
+
+## [2024-12-08]
+
+### Added
+- When updating the AFC software, the `install-afc.sh` script will now remove any instances of `[gcode_macro T#]` found in the `AFC_Macros.cfg`
+file as the code now generates them automatically.
+- Added logic to pause print when filament goes past prep sensor. Verify that PAUSE macro move's toolhead off print when it's called.
+
+## [2024-12-07]
+
+### Updated
+- When BT_TOOL_UNLOAD is used, spoolman active spool is set to None
+- When spool is ejected from Box Turtle spoolman spool is removed from variables
+- Activated espooler when user calls LANE_MOVE
+
+### Fixed
+- Fixed places where gcode was not referencing AFC and would cause crashes
+
+## [2024-12-04]
+
+### Fixed
+- Fixed issue with Turtleneck buffer pins not being assigned correctly when prompted during install
+- Fixed issue with LEDs not showing the right color when error happened during PREP
+- Changed error message when AFC.vars.unit lane showed loaded but AFC.vars.tool file didn't match
+- Added logic so that user could change trsync value. To set value add the following into `[AFC]` section in AFC.cfg file:  
+`trsync_update: True`  
+Optional:  
+`trsync_timeout: 0.05`  
+`TRSYNC_SINGLE_MCU_TIMEOUT: 0.5` 
+
+## [2024-12-03]
+
+### Added
+
+- The `install-afc.sh` script will now query the printer upon exit to see if it is actively printing. If it is not
+  printing, it will restart the `klipper` service.
+
+## [2024-12-02]
+
+### Added
+
+- Buffer_Ram_Sensor
+  - Enabling the buffer to be used as a ram sensor for loading and unloading filament
+  - see Buffer_Ram_Sensor doc for more information
+
+### Changed
+
+- Adjusted load and unload to account for ram sensor
+- Adjusted Prep to account for ram sensor
+
+## [2024-11-27]
+
+### Added
+- `self.delay` to AFC_Prep to control delay time during Prep
+  - Config option under `[AFC Prep]`, `delay_time: 1  # default .1`
+  - This can be increased if TTC occurs during prep caused by H-bridge command queue
+
+### Changed
+- Simplified enabling and disabling of the buffer
+- `AFC_extruder.py` now holds the functions and controls of the buffer
+  - These common functions all called throughout
+
+### Fixed
+- Fixed erroring out if a buffer in not configured
+
+## [2024-11-25]
+
+### Changed
+- Simplified buffer status to Trailing and Advancing
+  - Buffer tube moving from Trailing to Advance it is in the Advancing state
+  - Buffer tube moving from Advance to Trialing it is in the Trialing state
+
+## [2024-11-27]
+
+### Added
+
+- `generate_docs.py` utility in the `utilities` folder to auto-generate some basic documentation in the `docs/command_reference.md` file.
+
+## [2024-11-27]]
+
+### Fixed
+- Klipper erroring out when renaming `RESUME` macro when a user call's `BT_PREP` within the same reboot of klipper
+
+## [2024-11-23]
+
+### Added
+- New buffer function `SET_BUFFER_MULTIPLIER` used to live adjust the high and low multipliers for the buffer
+    - To change `multiplier_high`: `SET_BUFFER_MULTIPLIER MULTIPLIER=HIGH FACTOR=1.2`
+    - To change `multiplier_low`: `SET_BUFFER_MULTIPLIER MULTIPLIER=HIGH FACTOR=0.8`
+    - `MULTIPLIER` and `FACTOR` must be defined
+    - Buffer config section must be updated for values to be saved
+
+### Fixed
+-Corrected buffer to only trigger when tube comes onto switch/sensor and not off
+
+## [2024-11-22]
+
+### Changed
+
+*Full update, this needs more details*
+
+## [2024-11-16]
+
+### Added
+- New variable `cut_servo_name` for AFC_hub configuration to specify which servo to use
+- AFC_STATUS macro call, will print out what the current status is for each lane
+  
+  ex. 
+  ```
+  Turtle_1 Status
+  LANE | Prep | Load | Hub | Tool |
+  LEG1 |  xx  |  xx  |  x  |  xx  |
+  LEG2 |  xx  |  xx  |  x  |  xx  |
+  LEG3 |  xx  |  xx  |  x  |  xx  |
+  LEG4 |  xx  |  xx  |  x  |  xx  |
+  
+  Turtle_2 Status
+  LANE | Prep | Load | Hub | Tool |
+  LEG5 |  xx  |  xx  |  x  |  xx  |
+  LEG6 |  xx  |  xx  |  x  |  xx  |
+  LEG7 |  xx  |  xx  |  x  |  xx  |
+  LEG8 | <--> | <--> | <-> | <--> |
+  ```
+
+### Fixed
+- Fixed hub_cut function to work with new structure
+- Added sleeps back to hub_cut with reactor class
+
+## [2024-11-03]
+
+### Added
+
+- Manually add the following section to your `AFC.cfg`
+```
+#--=================================================================================--#
+######### Pause/Resume ################################################################
+#--=================================================================================--#
+xy_resume: False               # Enable to have position return to previous x,y coords after tool change
+resume_speed: 0                # Speed of resume move. Leave 0 to use current printer speed
+resume_z_speed: 0              # Speed of resume move in Z. Leave 0 to use current printer speed
+```
+- Manually add the following to your `AFC_macros.cfg`
+```
+[gcode_macro BT_RESUME]
+description: Resume the print after an error
+gcode:
+    {% if not printer.pause_resume.is_paused %}
+        RESPOND MSG="Print is not paused. Resume ignored"
+    {% else %}
+        AFC_RESUME
+    {% endif %}
+```
+- If you encounter an error use the *BT_RESUME* macro to resume to the proper z height after the error is fixed.
+
+### Changed
+
+- Save/Restore position to use proper gcode location
+- It will restore the z position first before making an x,y move
+
+## [2024-10-31]
+
+### Added
+
+- Added LED buffer_indicator
+  - allows for state change indication through color change
+- Added AFC_buffer.md to layout the integration of a buffer into the AFC system
+
+### Changed
+
+- Changed buffer code to reflect buffer functionality and pin names
+- Moved stepper commands from AFC_buffer to AFC_stepper
+- Abstracted buffer status to be used in IP query and query buffer
+
+## [2024-10-27]
+
+### Added
+
+- Updated the `install-afc.sh` script to include setup of the buffer configuration.
+- Added `part_cooling_fan_speed` to poop macro
+- Add `variable_part_cooling_fan_speed   : 1.0         # Speed to run fan when enabled above. 0 - 1.0` to your `_AFC_POOP_VARS` to change the value.
+
+### Changed
+
+- Broke the `install-afc.sh` script out into multiple files that are sourced by the main script for maintainability.
+
+### Fixed
+  - Fixed bug when `part_cooling_fan` was set to False
+
+## [2024-10-24]
+
+### Added
+
+ - Added `loaded_to_hub` parameter to get_status so users can see if filament is loaded to  their hub
+ - Added `SET_BOWDEN_LENGTH LENGTH={}` to change `afc_bowden_length`
+      - Length can be changed in 3 ways:
+          - An exact value can be set. `SET_BOWDEN_LENGTH LENGTH=955` will set the Bowden length to 955mm
+          - Current value can be incremented positive or negative.
+             - `SET_BOWDEN_LENGTH LENGTH=+100` if the original length was `955` it will be changed to `1055`
+             - `SET_BOWDEN_LENGTH LENGTH=-100` if the original length was `955` it will be changed to `855`
+       - `SET_BOWDEN_LENGTH` is called without a `LENGTH` specified then the value will be reset back to the configured length
+       - Changed distance will have to be manually updated in `AFC.cfg`  
+
+  - Added `Buffer_Name` to `AFC.cfg`
+    - this allows the code base to have a name for the buffer to reference.
+    - The name must match how buffer is defined in `[AFC_buffer *Buffer_Name*]`
+    - ^^^This has to be manually updated and must be uncommented/added to AFC.cfg file^^^
+  -  Additions to `AFC.py`
+    - establish Buffer name
+    - With buffer set up
+      - Enable during `PREP`
+      - Enable during `tool_load`
+      - Disable during `tool_unload`
+  - Added `SET_ROTATION_FACTOR` that uses variable `FACTOR`
+    - if a turtleneck style buffer is enabled it will change the current rotation distance of the AFC stepper,
+    - Values greater than 0
+    - Values greater than 1 will cause more filament to be fed
+    - Values Less than 1 greater than 0 will cause less filament to be fed
+    
+### Changed
+
+ - Revamped `install-afc.sh` script to be interactive and provide more configuration options for the user.
+ - Updated `ruff` GHA to only scan for changed files.
+ - Updates to AFC.cfg file. Be sure to back up current file and replace with new version, then update values from backed up file.
+ - Manually changes needed to AFC_hardware.cfg
+    - `[filament_switch_sensor tool]` update to `[filament_switch_sensor tool_start]`
+    - If using sensor after gears `[filament_switch_sensor extruder]` update to `[filament_switch_sensor tool_end]`
+
+  - Full functionality change for Turtleneck/ Turtleneck 2.0 style buffers
+  - Changed buffer configuration examples, new configuration is required for full functionality!
+    - `multiplier_high` controls the speed-up of filament being fed
+    - `multiplier_low` controls the slow-down of filament being fed
+  - `QUERY_BUFFER` will output rotation distance if applicable
+
+### Fixed
+
+  - Minor adjustments to the use of single sensor buffers, retaining functionality for Belay
+
+## [2024-08-28]
+
+### Added
+
+- Addition of two helper macros for the AFC system. 
+  - `BT_LANE_EJECT` - This macro will eject a specified box turtle lane.
+  - `BT_TOOL_UNLOAD` - This macro will unload a specified box turtle tool.
+
+- Sample configuration files for the most popular boards are located in the `Klipper_cfg_example/AFC` directory.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
## Summary
- add global runout enable flags and debounce configuration that are consumed throughout the AFC components
- introduce a DebounceButton helper and update filament switch registration to support delayed callbacks and GUI visibility toggles
- extend hubs, lanes, extruders, buffers, and logging with new runout handling, warning messaging, and changelog notes

## Testing
- python -m compileall AFC-Klipper-Add-On/extras

------
https://chatgpt.com/codex/tasks/task_e_68cefcae1488832690df0810ffb1f2ac