### PR TITLE
Apply motion queuing compatibility updates

### DIFF
--- a/AFC-Klipper-Add-On/CHANGELOG.md
+++ b/AFC-Klipper-Add-On/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2025-09-05]
+### Added
+- Check to verify that pin_tool_start/end is not set to `Unknown`, throws error if pins are set to `Unknown`.
+### Fixes
+- Compatibility issue with klipper after version v0.13.0-190-g5eb07966
+
+## [2025-09-01]
+### Fixes
+- Issue with older klipper version before debounce button was added
+
 ## [2025-08-30]
 ### Added
 - Catch for JSON decode error when trying to read and load AFC.var.unit file

--- a/AFC-Klipper-Add-On/extras/AFC.py
+++ b/AFC-Klipper-Add-On/extras/AFC.py
@@ -27,7 +27,7 @@ except: raise error(ERROR_STR.format(import_lib="AFC_utils", trace=traceback.for
 try: from extras.AFC_stats import AFCStats
 except: raise error(ERROR_STR.format(import_lib="AFC_stats", trace=traceback.format_exc()))
 
-AFC_VERSION="1.0.29"
+AFC_VERSION="1.0.31"
 
 # Class for holding different states so its clear what all valid states are
 class State:

--- a/AFC-Klipper-Add-On/extras/AFC_extruder.py
+++ b/AFC-Klipper-Add-On/extras/AFC_extruder.py
@@ -42,6 +42,9 @@ class AFCExtruder:
 
         self.tool_start_state = False
         if self.tool_start is not None:
+            if "unknown" == self.tool_start.lower():
+                raise error(f"Unknown is not valid for pin_tool_start in [{self.fullname}] config.")
+
             if self.tool_start == "buffer":
                 self.logger.info("Setting up as buffer")
             else:
@@ -52,6 +55,9 @@ class AFCExtruder:
 
         self.tool_end_state = False
         if self.tool_end is not None:
+            if "unknown" == self.tool_end.lower():
+                raise error(f"Unknown is not valid for pin_tool_end in [{self.fullname}] config.")
+
             buttons.register_buttons([self.tool_end], self.tool_end_callback)
             self.fila_tool_end, self.debounce_button_end = add_filament_switch("tool_end", self.tool_end, self.printer,
                                                                                 self.enable_sensors_in_gui, self.handle_end_runout, self.enable_runout,

--- a/AFC-Klipper-Add-On/extras/AFC_stepper.py
+++ b/AFC-Klipper-Add-On/extras/AFC_stepper.py
@@ -17,20 +17,32 @@ except: raise error("Error when trying to import AFC_utils.ERROR_STR\n{trace}".f
 try: from extras.AFC_lane import AFCLane
 except: raise error(ERROR_STR.format(import_lib="AFC_lane", trace=traceback.format_exc()))
 
+LARGE_TIME_OFFSET = 99999.9
+
 class AFCExtruderStepper(AFCLane):
     def __init__(self, config):
         super().__init__(config)
 
         self.extruder_stepper   = extruder.ExtruderStepper(config)
 
-        self.motion_queue = None
+        # Check for Klipper new motion queuing update
+        try:
+            self.motion_queuing = self.printer.load_object(config, "motion_queuing")
+        except Exception:
+            self.motion_queuing = None
+
         self.next_cmd_time = 0.
         ffi_main, ffi_lib = chelper.get_ffi()
-        self.trapq = ffi_main.gc(ffi_lib.trapq_alloc(), ffi_lib.trapq_free)
-        self.trapq_append = ffi_lib.trapq_append
-        self.trapq_finalize_moves = ffi_lib.trapq_finalize_moves
         self.stepper_kinematics = ffi_main.gc(
             ffi_lib.cartesian_stepper_alloc(b'x'), ffi_lib.free)
+        if self.motion_queuing is not None:
+            self.trapq = self.motion_queuing.allocate_trapq()
+            self.trapq_append = self.motion_queuing.lookup_trapq_append()
+            self.trapq_finalize_moves = None
+        else:
+            self.trapq = ffi_main.gc(ffi_lib.trapq_alloc(), ffi_lib.trapq_free)
+            self.trapq_append = ffi_lib.trapq_append
+            self.trapq_finalize_moves = ffi_lib.trapq_finalize_moves
         self.assist_activate=False
 
         # Current to use while printing, set to a lower current to reduce stepper heat when printing.
@@ -69,24 +81,30 @@ class AFCExtruderStepper(AFCLane):
 
 
         with self.assist_move(speed, distance < 0, assist_active):
+            # Code based off force_move.py manual_move function
             toolhead = self.printer.lookup_object('toolhead')
             toolhead.flush_step_generation()
-            prev_sk = self.extruder_stepper.stepper.set_stepper_kinematics(self.stepper_kinematics)
-            prev_trapq = self.extruder_stepper.stepper.set_trapq(self.trapq)
+            prev_sk     = self.extruder_stepper.stepper.set_stepper_kinematics(self.stepper_kinematics)
+            prev_trapq  = self.extruder_stepper.stepper.set_trapq(self.trapq)
             self.extruder_stepper.stepper.set_position((0., 0., 0.))
             axis_r, accel_t, cruise_t, cruise_v = calc_move_time(distance, speed, accel)
             print_time = toolhead.get_last_move_time()
             self.trapq_append(self.trapq, print_time, accel_t, cruise_t, accel_t,
                               0., 0., 0., axis_r, 0., 0., 0., cruise_v, accel)
             print_time = print_time + accel_t + cruise_t + accel_t
-            self.extruder_stepper.stepper.generate_steps(print_time)
-            self.trapq_finalize_moves(self.trapq, print_time + 99999.9,
-                                      print_time + 99999.9)
-            self.extruder_stepper.stepper.set_trapq(prev_trapq)
-            self.extruder_stepper.stepper.set_stepper_kinematics(prev_sk)
-            toolhead.note_mcu_movequeue_activity(print_time)
+            if self.motion_queuing is None:
+                self.extruder_stepper.stepper.generate_steps(print_time)
+                self.trapq_finalize_moves(self.trapq, print_time + LARGE_TIME_OFFSET,
+                                          print_time + LARGE_TIME_OFFSET)
+                toolhead.note_mcu_movequeue_activity(print_time)
+            else:
+                self.motion_queuing.note_mcu_movequeue_activity(print_time)
             toolhead.dwell(accel_t + cruise_t + accel_t)
             toolhead.flush_step_generation()
+            self.extruder_stepper.stepper.set_trapq(prev_trapq)
+            self.extruder_stepper.stepper.set_stepper_kinematics(prev_sk)
+            if self.motion_queuing is not None:
+                self.motion_queuing.wipe_trapq(self.trapq)
             toolhead.wait_moves()
 
     def move(self, distance, speed, accel, assist_active=False):


### PR DESCRIPTION
## Summary
- add the September 2025 changelog entries introduced upstream
- bump the AFC add-on version to 1.0.31 and validate that toolhead pins are not left as "Unknown"
- update the AFC stepper helper to work with Klipper's newer motion_queuing API while retaining the legacy path

## Testing
- python -m compileall AFC-Klipper-Add-On/extras

------
https://chatgpt.com/codex/tasks/task_e_68d01619c7708326866e16055aad4bf5