### PR TITLE
Sync AFC stepper trap queue handling with upstream commit 07ff136ae8239fdd6c02325e3791c42e9c0f806a

### DIFF
--- a/AFC-Klipper-Add-On/extras/AFC_stepper.py
+++ b/AFC-Klipper-Add-On/extras/AFC_stepper.py
@@ -32,17 +32,19 @@ class AFCExtruderStepper(AFCLane):
             self.motion_queuing = None
 
         self.next_cmd_time = 0.
+
         ffi_main, ffi_lib = chelper.get_ffi()
         self.stepper_kinematics = ffi_main.gc(
             ffi_lib.cartesian_stepper_alloc(b'x'), ffi_lib.free)
+
         if self.motion_queuing is not None:
-            self.trapq = self.motion_queuing.allocate_trapq()
-            self.trapq_append = self.motion_queuing.lookup_trapq_append()
-            self.trapq_finalize_moves = None
+            self.trapq          = self.motion_queuing.allocate_trapq()
+            self.trapq_append   = self.motion_queuing.lookup_trapq_append()
         else:
-            self.trapq = ffi_main.gc(ffi_lib.trapq_alloc(), ffi_lib.trapq_free)
-            self.trapq_append = ffi_lib.trapq_append
-            self.trapq_finalize_moves = ffi_lib.trapq_finalize_moves
+            self.trapq                  = ffi_main.gc(ffi_lib.trapq_alloc(), ffi_lib.trapq_free)
+            self.trapq_append           = ffi_lib.trapq_append
+            self.trapq_finalize_moves   = ffi_lib.trapq_finalize_moves
+
         self.assist_activate=False
 
         # Current to use while printing, set to a lower current to reduce stepper heat when printing.
@@ -92,13 +94,15 @@ class AFCExtruderStepper(AFCLane):
             self.trapq_append(self.trapq, print_time, accel_t, cruise_t, accel_t,
                               0., 0., 0., axis_r, 0., 0., 0., cruise_v, accel)
             print_time = print_time + accel_t + cruise_t + accel_t
+
             if self.motion_queuing is None:
                 self.extruder_stepper.stepper.generate_steps(print_time)
                 self.trapq_finalize_moves(self.trapq, print_time + LARGE_TIME_OFFSET,
-                                          print_time + LARGE_TIME_OFFSET)
+                                        print_time + LARGE_TIME_OFFSET)
                 toolhead.note_mcu_movequeue_activity(print_time)
             else:
                 self.motion_queuing.note_mcu_movequeue_activity(print_time)
+
             toolhead.dwell(accel_t + cruise_t + accel_t)
             toolhead.flush_step_generation()
             self.extruder_stepper.stepper.set_trapq(prev_trapq)


### PR DESCRIPTION
## Summary
- align AFC stepper trap queue initialization and motion_queuing handling with upstream commit 07ff136ae8239fdd6c02325e3791c42e9c0f806a
- mirror upstream formatting so the local copy matches the referenced commit

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d017c4c54c832696740590e6b9c71a