### PR TITLE
Gate pause command on active prints

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,251 @@
+# Sovoron Klipper AFC & OpenAMS Integration Guide
+
+This repository packages the firmware modules, configuration, and macros required to run Sovoron printers with both the Automatic Filament Changer (AFC) and the OpenAMS multi-spool management system. It combines the upstream `klipper_openams` Python extension with a complete Klipper configuration tailored for dual OpenAMS units feeding an AFC-based toolchanger.
+
+## Table of Contents
+1. [System Architecture](#system-architecture)
+   1. [Software Components](#software-components)
+   2. [Hardware & MCU Topology](#hardware--mcu-topology)
+   3. [Filament Path & Monitoring](#filament-path--monitoring)
+2. [Integration Workflow](#integration-workflow)
+   1. [Spool Loading & Switchover](#spool-loading--switchover)
+   2. [Runout, Clog, and Stuck Spool Handling](#runout-clog-and-stuck-spool-handling)
+   3. [Macros Bridging AFC and OpenAMS](#macros-bridging-afc-and-openams)
+3. [Configuration Reference](#configuration-reference)
+   1. [OpenAMS Core (`printer_data/config/oamsc.cfg`)](#openams-core-printer_dataconfigoamsccfg)
+   2. [OpenAMS Macros (`printer_data/config/oams_macros.cfg`)](#openams-macros-printer_dataconfigoams_macroscfg)
+   3. [AFC Core Settings (`printer_data/config/AFC/AFC.cfg`)](#afc-core-settings-printer_dataconfigafcafccfg)
+   4. [AFC Macro Variables (`printer_data/config/AFC/AFC_Macro_Vars.cfg`)](#afc-macro-variables-printer_dataconfigafcafc_macro_varscfg)
+   5. [AFC Hardware Definition (`printer_data/config/AFC/AFC_Hardware.cfg`)](#afc-hardware-definition-printer_dataconfigafcafc_hardwarecfg)
+   6. [AFC AMS/Lane Mapping (`printer_data/config/AFC/AFC_AMS*.cfg`)](#afc-amslane-mapping-printer_dataconfigafcafc_amscfg)
+   7. [Box Turtle & Buffers (`printer_data/config/AFC/AFC_Turtle_1.cfg`)](#box-turtle--buffers-printer_dataconfigafcafc_turtle_1cfg)
+   8. [Pico Coprocessor (`printer_data/config/AFC/AFC_Pico.cfg`)](#pico-coprocessor-printer_dataconfigafcafc_picocfg)
+   9. [AFC Convenience Macros (`printer_data/config/AFC/macros/*.cfg`)](#afc-convenience-macros-printer_dataconfigafcmacroscfg)
+4. [Extending the Setup](#extending-the-setup)
+   1. [Adding Additional OpenAMS Units](#adding-additional-openams-units)
+   2. [Customising AFC Behaviour](#customising-afc-behaviour)
+   3. [Debugging & Monitoring Tips](#debugging--monitoring-tips)
+
+---
+
+## System Architecture
+
+### Software Components
+- **`klipper_openams` extension** – Implements the runtime logic that coordinates spool loading, runout recovery, clog detection, and stuck-spool monitoring across all filament pressure sensors (FPS) and AMS hubs. The `oams_manager.py` module provides configurable thresholds, timers, and LED control hooks that interact with the hardware macros defined in the Klipper configuration.
+- **Klipper configuration** – Located under `printer_data/config`, it declares all MCUs, stepper lanes, hubs, macros, and gcode variables that tie the OpenAMS hardware to the AFC system. The configuration is separated into logical files so each subsystem can be tuned independently.
+
+### Hardware & MCU Topology
+- **OpenAMS MCUs** – `oamsc.cfg` declares the CAN-connected MCUs for each FPS and hub pair (`[mcu fps]`, `[mcu oams_mcu1]`, and matching entries for the second AMS). Multiple filament pressure sensors can be defined to support dual extruders.
+- **AFC controllers** – `AFC_Turtle_1.cfg` and `AFC_Pico.cfg` register the Box Turtle CAN board and RP2040-based buffer expander that drive lane steppers, hub motors, and buffer sensors. Each lane maps to an AFC stepper with its own TMC2209 driver configuration and optional buffer logic.
+
+### Filament Path & Monitoring
+- **Filament groups & FPS definitions** – `oamsc.cfg` maps toolchanger tools (`T4`–`T11`) into OpenAMS filament groups and binds each group to an FPS (`fps1`/`fps2`) and extruder. The `reload_before_toolhead_distance` value per FPS determines how early the manager coasts followers before a swap.
+- **Pressure and encoder tracking** – `klipper_openams/src/oams_manager.py` tracks encoder counts and FPS pressure, automatically retrying failed loads, pausing when loading speeds stall, and latching LEDs when a stuck spool is detected. Clog monitoring uses configurable dwell, travel, and pressure thresholds to decide when to stop a print.
+
+## Integration Workflow
+
+### Spool Loading & Switchover
+1. **Lane selection** – AFC lanes are mapped to OpenAMS units (`[AFC_lane]` sections) so that commands like `CHANGE_TOOL` or `_TX1` select the correct group before requesting a load.
+2. **Load execution** – `OAMSM_LOAD_FILAMENT` gcode is emitted by the `_TX1`/`_TX2` macros. The OpenAMS manager advances the designated hub until the FPS reaches the configured midpoint between `fps_upper_threshold` and `fps_lower_threshold`.
+3. **Toolhead priming** – After a successful load, macros pull filament into the toolhead using the `_oams_macro_variables` lengths and optionally trigger purge, wipe, or brush cycles defined in AFC macro variables.
+
+### Runout, Clog, and Stuck Spool Handling
+- **Runout** – When an FPS detects hub HES sensors dropping out, `OAMSRunoutMonitor` transitions through pause, coast, and reload states before pulling the next spool in the group.
+- **Clog detection** – Encoder deltas, extruder travel, and pressure offsets are sampled over the configurable window to determine whether extrusion has stalled. If a clog is confirmed, the print is paused and LEDs illuminate for the offending spool.
+- **Stuck spool detection** – While printing, the stuck spool monitor watches FPS pressure for sustained readings below `STUCK_SPOOL_PRESSURE_TRIGGER`. If the pressure stays low for at least the clog dwell time, the system pauses, asserts the spool LED, and waits for the user to resume after clearing the jam. Resuming or switching spools automatically clears the latch and LED.
+
+### Macros Bridging AFC and OpenAMS
+- **Safe unload routines** – `SAFE_UNLOAD_FILAMENT1/2` macros coordinate nozzle heating, cutter actuation, follower reversal, and hub unload commands for each AMS.
+- **Transfer macros** – `_TX1` and `_TX2` manage changeovers by unloading the currently loaded group (if any), loading the requested OpenAMS group, and priming the toolhead before returning to print moves.
+- **Convenience wrappers** – `BT_CHANGE_TOOL`, `BT_LANE_EJECT`, and related macros provide high-level commands for tool changes and manual lane operations while respecting the underlying AFC lane naming conventions.
+
+## Configuration Reference
+
+### OpenAMS Core (`printer_data/config/oamsc.cfg`)
+
+#### MCU & Sensor Blocks
+| Section | Settings | Purpose |
+| --- | --- | --- |
+| `[mcu fps]` | `canbus_uuid` | CAN address for the first filament pressure sensor MCU. |
+| `[mcu oams_mcu1]` | `canbus_uuid` | CAN address for the first OpenAMS hub MCU. |
+| `[mcu fps2]` | `canbus_uuid` | Optional second FPS MCU for dual extruders. |
+| `[mcu oams_mcu2]` | `canbus_uuid` | Optional second OpenAMS hub MCU. |
+| `[filament_switch_sensor extruder_in1]` | `switch_pin`, `pause_on_runout` | Optional inline filament sensor for the first toolhead. |
+| `[filament_switch_sensor extruder_in2]` | `switch_pin`, `pause_on_runout` | Optional inline filament sensor for the second toolhead. |
+
+#### Macro Variable Block
+| Section | Variable | Description |
+| --- | --- | --- |
+| `[gcode_macro _oams_macro_variables]` | `variable_pre_cut_x`, `variable_pre_cut_y`, `variable_pre_cut_speed`, `variable_cut_x`, `variable_cut_y`, `variable_cut_speed` | Cutter entry positions and speeds. |
+|  | `variable_hotend_meltzone_compensation`, `variable_retract_length`, `variable_extrusion_reload_length`, `variable_extrusion_unload_length`, `variable_reload_speed` | Toolhead extrusion lengths and speeds for load/unload cycles. |
+|  | `variable_fs_extruder_in1`, `variable_fs_extruder_out1`, `variable_fs_extruder_in2`, `variable_fs_extruder_out2` | Enable flags for auxiliary filament sensors per extruder. |
+
+#### OpenAMS Unit Blocks
+| Section | Key Settings | Description |
+| --- | --- | --- |
+| `[oams oams1]` & `[oams oams2]` | `fps_upper_threshold`, `fps_lower_threshold`, `fps_is_reversed`, `f1s_hes_on`, `f1s_hes_is_above`, `hub_hes_on`, `hub_hes_is_above`, `ptfe_length`, `current_target`, `current_kp`, `current_ki`, `current_kd`, `oams_idx` | Tune how each AMS responds to FPS pressure, HES sensors, PTFE length, and rewind PID. |
+
+#### Filament Groups & FPS Definitions
+| Section | Settings | Description |
+| --- | --- | --- |
+| `[filament_group T4]` … `[filament_group T11]` | `group` | Map toolchanger tools to OpenAMS spool groups. |
+| `[fps fps1]` & `[fps fps2]` | `pin`, `reversed`, `oams`, `extruder`, `reload_before_toolhead_distance` | Bind an FPS sensor to its AMS, extruder, and follower safety margin. |
+
+#### Manager & Includes
+| Section | Settings | Description |
+| --- | --- | --- |
+| `[oams_manager]` | (commented) `UNLOAD_RETRY_NUDGE_TIME`, `reload_before_toolhead_distance` | Optional overrides for retry timing and follower safety margin. |
+| `[include oams_macros.cfg]` | — | Pulls in all macros that cooperate with the manager. |
+
+### OpenAMS Macros (`printer_data/config/oams_macros.cfg`)
+
+| Macro | Role |
+| --- | --- |
+| `SAFE_UNLOAD_FILAMENT1`, `SAFE_UNLOAD_FILAMENT2` | Heat the nozzle, actuate the cutter, command follower reversal, and unload the active spool for AMS 1 and 2 respectively. |
+| `_TX1`, `_TX2` | High-level transfer macros that unload the current group, request an OpenAMS load (`OAMSM_LOAD_FILAMENT`), prime the extruder, and restore print state for each FPS. |
+| `_UNLOAD_FS_OUT1`, `_UNLOAD_FS_OUT2`, `_LOAD_FS_IN1`, `_LOAD_FS_OUT1` (and similar helpers) | Internal helper macros that synchronise auxiliary filament sensors with hub and toolhead movement. |
+
+### AFC Core Settings (`printer_data/config/AFC/AFC.cfg`)
+
+#### Speed & Motion
+| Setting | Description |
+| --- | --- |
+| `long_moves_speed`, `long_moves_accel` | Feed rate/acceleration for long lane moves. |
+| `short_moves_speed`, `short_moves_accel`, `short_move_dis` | Parameters for short failsafe moves used during retries. |
+| `load_to_hub` | Global toggle for automatically fast-loading filament to the hub when a spool is inserted. |
+| `assisted_unload` | Whether the hub assists retracts during unload to prevent loose windings. |
+| `unload_on_runout` | Enables automatic unload on runout if no fallback spool is configured. |
+| `print_short_stats`, `debug`, `auto_home`, `debounce_delay` | Runtime logging and safety toggles. |
+
+#### Material & Sensor Defaults
+| Setting | Description |
+| --- | --- |
+| `enable_sensors_in_gui` | Expose sensors in the UI for monitoring. |
+| `default_material_temps`, `common_density_values`, `default_material_type` | Default extrusion parameters when Spoolman data is unavailable. |
+
+#### Pause/Resume Behaviour
+| Setting | Description |
+| --- | --- |
+| `z_hop`, `resume_speed`, `resume_z_speed`, `error_timeout` | Head movement and timeout behaviour around tool changes and errors. |
+
+#### LED Colours
+| Setting | Description |
+| --- | --- |
+| `led_name`, `led_fault`, `led_ready`, `led_not_ready`, `led_loading`, `led_tool_loaded`, `led_buffer_advancing`, `led_buffer_trailing`, `led_buffer_disable`, `led_spool_illuminate` | Neopixel colours used to indicate AFC state transitions. |
+
+#### Macro Enablement
+| Setting | Description |
+| --- | --- |
+| `tool_cut`, `tool_cut_threshold`, `tool_cut_cmd` | Enable and configure cutter usage during unload. |
+| `park`, `park_cmd` | Enable toolhead park routine. |
+| `poop`, `poop_cmd`, `kick`, `kick_cmd`, `wipe`, `wipe_cmd`, `form_tip`, `form_tip_cmd` | Toggle purge, kick, brush, and tip-form routines. |
+
+#### Startup & Tip Forming
+| Section | Key Settings |
+| --- | --- |
+| `[AFC_prep]` | `enable` toggles the PREP routine executed by `delayed_gcode welcome`. |
+| `[AFC_form_tip]` | `ramming_volume`, `toolchange_temp`, `unloading_speed_start`, `unloading_speed`, `cooling_tube_position`, `cooling_tube_length`, `initial_cooling_speed`, `final_cooling_speed`, `cooling_moves`, `use_skinnydip`, `skinnydip_distance`, `dip_insertion_speed`, `dip_extraction_speed`, `melt_zone_pause`, `cooling_zone_pause`. |
+
+### AFC Macro Variables (`printer_data/config/AFC/AFC_Macro_Vars.cfg`)
+
+#### `_AFC_GLOBAL_VARS`
+| Variable | Description |
+| --- | --- |
+| `variable_stepper_name` | Prefix for AFC lane steppers (e.g., `lane`). |
+| `variable_travel_speed`, `variable_z_travel_speed`, `variable_accel` | Default travel speeds and acceleration for macro moves. |
+| `variable_verbose` | Console verbosity level (0–2). |
+
+#### `_AFC_CUT_TIP_VARS`
+| Variable | Description |
+| --- | --- |
+| `variable_pin_loc_xy`, `variable_pin_park_dist`, `variable_cut_move_dist` | Cutter positioning parameters. |
+| `variable_cut_accel`, `variable_cut_direction`, `variable_cut_fast_move_speed`, `variable_cut_slow_move_speed`, `variable_evacuate_speed`, `variable_cut_dwell_time`, `variable_cut_fast_move_fraction`, `variable_extruder_move_speed` | Motion profile for cutting. |
+| `variable_restore_position`, `variable_retract_length`, `variable_quick_tip_forming`, `variable_cut_count`, `variable_rip_length`, `variable_rip_speed`, `variable_pushback_length`, `variable_pushback_dwell_time` | Behavioural tweaks for retracting and tip shaping. |
+| `variable_safe_margin_xy` | Safety envelope when approaching the cutter. |
+| `variable_cut_current_stepper_x`, `variable_cut_current_stepper_y`, `variable_cut_current_stepper_z`, `variable_conf_name_stepper_x`, `variable_conf_name_stepper_y`, `variable_conf_name_stepper_z` | Optional current overrides and matching TMC section names. |
+| `variable_tool_servo_enable`, `variable_tool_servo_name`, `variable_tool_servo_angle_out`, `variable_tool_servo_angle_in` | Servo configuration for blade actuation. |
+
+#### `_AFC_POOP_VARS`
+| Variable | Description |
+| --- | --- |
+| `variable_purge_loc_xy`, `variable_purge_spd`, `variable_z_purge_move`, `variable_fast_z`, `variable_z_lift` | Purge path geometry and speeds. |
+| `variable_restore_position`, `variable_purge_start` | Toolhead positioning before/after purging. |
+| `variable_part_cooling_fan`, `variable_part_cooling_fan_speed`, `variable_purge_cool_time` | Cooling fan usage during purge. |
+| `variable_purge_length`, `variable_purge_length_minimum` (+ optional modifiers) | Filament length heuristics for purging. |
+
+#### `_AFC_KICK_VARS`
+| Variable | Description |
+| --- | --- |
+| `variable_kick_start_loc`, `variable_kick_z`, `variable_kick_speed`, `variable_kick_accel`, `variable_kick_direction`, `variable_kick_move_dist`, `variable_z_after_kick` | Parameters for the kick routine that knocks purge blobs off the deck. |
+
+#### `_AFC_BRUSH_VARS`
+| Variable | Description |
+| --- | --- |
+| `variable_brush_loc`, `variable_brush_clean_speed`, `variable_brush_clean_accel`, `variable_brush_width`, `variable_brush_depth`, `variable_y_brush`, `variable_brush_count`, `variable_z_move` | Define brush location, speeds, passes, and optional Z hop. |
+
+#### `_AFC_PARK_VARS`
+| Variable | Description |
+| --- | --- |
+| `variable_park_loc_xy`, `variable_z_hop`, `variable_park_z` | Position and Z management during park moves. |
+
+### AFC Hardware Definition (`printer_data/config/AFC/AFC_Hardware.cfg`)
+
+| Section | Key Settings |
+| --- | --- |
+| `[force_move]` | `enable_force_move` enables manual jogs with unloaded steppers. |
+| `[AFC_extruder extruder*]` | `pin_tool_start`, optional `pin_tool_end`, `tool_stn`, `tool_stn_unload`, `tool_sensor_after_extruder`, `tool_unload_speed`, `tool_load_speed`, `deadband` define toolhead sensor geometry and speeds for each extruder channel. |
+| `[#filament_switch_sensor bypass]` | Template for an additional bypass sensor if needed. |
+
+### AFC AMS/Lane Mapping (`printer_data/config/AFC/AFC_AMS*.cfg`)
+
+| Section | Purpose |
+| --- | --- |
+| `[gcode_button T4_unload_button]`, `[gcode_button T5_unload_button]` | Hardware buttons that trigger `SAFE_UNLOAD_FILAMENT` routines when the printer is idle. |
+| `[AFC_AMS AMS_1]`, `[AFC_AMS AMS_2]` | Bind an OpenAMS unit (`oams1`/`oams2`) to the AFC extruder channel that services it. |
+| `[AFC_lane lane4]` … `[AFC_lane lane11]` | Assign individual lanes to AMS slots, define LED indices, hub IDs, tool mappings, and custom load/unload macros per lane. |
+| `[AFC_hub Hub_1]` … `[AFC_hub Hub_8]` | Configure bowden lengths, movement distances, and cutter availability for each hub. |
+
+### Box Turtle & Buffers (`printer_data/config/AFC/AFC_Turtle_1.cfg`)
+
+| Section | Highlights |
+| --- | --- |
+| `[AFC_BoxTurtle Turtle_1]` | Enables assist and kick-start behaviour for the Box Turtle hub controller and optionally links buffers. |
+| `[AFC_stepper lane0]` … `[AFC_stepper lane3]` | Define CAN pins, rotation distances, hub associations, buffers, and tool mappings for the four primary AFC lanes serviced by the Turtle board. |
+| `[tmc2209 AFC_stepper lane*]` | UART pins and current settings for each lane’s stepper driver. |
+| `[AFC_buffer TN*]` | Buffer advance/trailing sensors and gain multipliers (including those hosted on the Pico coprocessor). |
+| `[AFC_led AFC_Indicator]`, `[AFC_led AFC_Tndicator]`, `[AFC_led AFC_Sndicator]` | LED strips that visualise AFC state per AMS. |
+
+### Pico Coprocessor (`printer_data/config/AFC/AFC_Pico.cfg`)
+
+| Section | Highlights |
+| --- | --- |
+| `[mcu Pico]` | Registers the USB-connected RP2040 board that supplies additional GPIO for buffer sensors. |
+
+### AFC Convenience Macros (`printer_data/config/AFC/macros/*.cfg`)
+
+| Macro | Description |
+| --- | --- |
+| `BT_TOOL_UNLOAD` | Wrapper that issues `TOOL_UNLOAD` to drop the current filament. |
+| `BT_CHANGE_TOOL` | Calculates the lane name from `_AFC_GLOBAL_VARS.variable_stepper_name` and calls `CHANGE_TOOL`. |
+| `BT_LANE_EJECT` | Fully ejects filament from a specified lane. |
+| `BT_LANE_MOVE` | Manually advances or retracts a lane by a user-specified distance. |
+| `BT_RESUME` | Ensures AFC resume logic runs before resuming a paused print. |
+| `BT_PREP` | Runs the AFC PREP sequence via the `PREP` macro. |
+
+## Extending the Setup
+
+### Adding Additional OpenAMS Units
+- Duplicate the `[mcu fps]`, `[mcu oams_mcu]`, `[oams]`, `[filament_group]`, and `[fps]` sections with new UUIDs and group names. Ensure each new FPS is mapped to an extruder and lane macros reference the expanded group list.
+
+### Customising AFC Behaviour
+- Adjust macro variables in `AFC_Macro_Vars.cfg` to tune cutter timing, purge lengths, and brush routines for your specific toolhead and waste handling setup.
+- Modify lane definitions in `AFC_Turtle_1.cfg` to change hub assignments, add buffers, or alter LED indices when you relocate hardware.
+
+### Debugging & Monitoring Tips
+- Follow the comments in `oamsc.cfg` to calibrate FPS reversal, HES thresholds, and PTFE lengths. Use `tail -f ~/printer_data/logs/klippy.log` during calibration.
+- Inspect the AFC LEDs defined in `AFC.cfg` and `AFC_Turtle_1.cfg` to confirm status changes during loads, unloads, and error states.
+- Use the `SAFE_UNLOAD_FILAMENT` macros when clearing jams—resuming the print will clear stuck spool latches and LEDs automatically.
+
+---
+
+With these references, you can tune every aspect of the Sovoron AFC + OpenAMS integration, extend it to additional lanes or AMS units, and understand how the runtime code and macros cooperate to keep filament flowing reliably.

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ This repository packages the firmware modules, configuration, and macros require
 #### Manager & Includes
 | Section | Settings | Description |
 | --- | --- | --- |
-| `[oams_manager]` | (commented) `UNLOAD_RETRY_NUDGE_TIME`, `reload_before_toolhead_distance` | Optional overrides for retry timing and follower safety margin. |
+| `[oams_manager]` | (commented) `UNLOAD_RETRY_NUDGE_TIME`, `reload_before_toolhead_distance`, `follower_reassert_delay` | Optional overrides for retry timing, follower safety margin, and how quickly the follower command is reasserted after loads. |
 | `[include oams_macros.cfg]` | — | Pulls in all macros that cooperate with the manager. |
 
 ### OpenAMS Macros (`printer_data/config/oams_macros.cfg`)

--- a/klipper_openams/src/oams_manager.py
+++ b/klipper_openams/src/oams_manager.py
@@ -37,11 +37,19 @@ CLOG_WINDOW_MIN_MM = 12.0
 CLOG_WINDOW_MAX_MM = 48.0
 CLOG_ENCODER_DELTA_MIN = 3.0
 CLOG_ENCODER_DELTA_MAX = 15.0
+# Pressure tolerance (+/- window) around the target FPS value that still counts as
+# "on target" for clog detection. Hardware regulates around ~0.5, so we treat
+# sustained readings within this window as nominal load pressure.
 CLOG_PRESSURE_OFFSET_MIN = 0.10
 CLOG_PRESSURE_OFFSET_MAX = 0.30
 CLOG_DWELL_MIN = 4.0
 CLOG_DWELL_MAX = 14.0
 CLOG_RETRACTION_TOLERANCE_MM = 0.8
+
+# Spool jam detection
+STUCK_SPOOL_PRESSURE_TRIGGER = 0.08  # Pressure level indicating the spool is likely stuck
+# Follower keepalive cadence for loaded lanes
+FOLLOWER_RECOVERY_RETRY_INTERVAL = 1.5  # Seconds between follower keepalive assertions
 
 
 
@@ -142,7 +150,15 @@ class OAMSRunoutMonitor:
                 traveled_distance = fps.extruder.last_position - self.runout_position
                 if traveled_distance >= PAUSE_DISTANCE:
                     logging.info("OAMS: Pause complete, coasting the follower.")
-                    self.oams[fps_state.current_oams].set_oams_follower(0, 1)
+                    direction = (
+                        fps_state.direction
+                        if fps_state.direction in (0, 1)
+                        else 1
+                    )
+                    self.oams[fps_state.current_oams].set_oams_follower(0, direction)
+                    fps_state.following = False
+                    fps_state.direction = direction
+                    fps_state.last_follower_enable_time = 0.0
                     self.bldc_clear_position = fps.extruder.last_position
                     self.runout_after_position = 0.0
                     self.state = OAMSRunoutState.COASTING
@@ -271,8 +287,10 @@ class FPSState:
 
         # Follower state
         self.following: bool = False  # Whether follower mode is active
-        self.direction: int = 0  # Follower direction (0=forward, 1=reverse)
+        self.direction: Optional[int] = None  # Preferred follower direction
         self.since: Optional[float] = None  # Timestamp when current state began
+        self.last_follower_enable_time: float = 0.0  # Last time we commanded the follower
+        self.pending_follower_enable_timer = None  # Reactor timer used to re-assert follower enable
 
         # AFC delegation state
         self.afc_delegation_active: bool = False
@@ -286,8 +304,20 @@ class FPSState:
         self.clog_extruder_delta: float = 0.0
         self.clog_encoder_delta: float = 0.0
         self.clog_max_pressure: float = 0.0
+        self.clog_min_pressure: float = 1.0
         self.clog_start_time: Optional[float] = None
+        self.clog_encoder_activity: bool = False
 
+        # Stuck spool detection tracker
+        self.stuck_spool_start_time: Optional[float] = None
+        self.stuck_spool_active: bool = False
+        self.stuck_spool_last_oams: Optional[str] = None
+        self.stuck_spool_last_spool_idx: Optional[int] = None
+        self.stuck_spool_led_asserted: bool = False
+        self.stuck_spool_should_restore_follower: bool = False
+        self.stuck_spool_restore_direction: int = 0
+
+        self.reset_stuck_spool_state()
         self.reset_clog_tracker()
 
 
@@ -296,6 +326,7 @@ class FPSState:
         self.runout_position = None
         self.runout_after_position = None
         self.reset_clog_tracker()
+        self.reset_stuck_spool_state()
 
     def reset_clog_tracker(self) -> None:
         """Reset clog detection accumulation state."""
@@ -306,7 +337,20 @@ class FPSState:
         self.clog_extruder_delta = 0.0
         self.clog_encoder_delta = 0.0
         self.clog_max_pressure = 0.0
+        self.clog_min_pressure = 1.0
         self.clog_start_time = None
+        self.clog_encoder_activity = False
+        self.stuck_spool_start_time = None
+
+    def reset_stuck_spool_state(self) -> None:
+        """Clear stuck spool detection latches and history."""
+        self.stuck_spool_start_time = None
+        self.stuck_spool_active = False
+        self.stuck_spool_last_oams = None
+        self.stuck_spool_last_spool_idx = None
+        self.stuck_spool_led_asserted = False
+        self.stuck_spool_should_restore_follower = False
+        self.stuck_spool_restore_direction = 0
 
     def prime_clog_tracker(
         self,
@@ -322,8 +366,11 @@ class FPSState:
         self.clog_last_encoder = encoder_position
         self.clog_extruder_delta = 0.0
         self.clog_encoder_delta = 0.0
-        self.clog_max_pressure = max(pressure, 0.0)
+        clamped_pressure = max(pressure, 0.0)
+        self.clog_max_pressure = clamped_pressure
+        self.clog_min_pressure = clamped_pressure
         self.clog_start_time = timestamp
+        self.clog_encoder_activity = False
 
     def __repr__(self) -> str:
         return f"FPSState(state_name={self.state_name}, current_group={self.current_group}, current_oams={self.current_oams}, current_spool_idx={self.current_spool_idx})"
@@ -353,7 +400,10 @@ class OAMSManager:
         self.config = config
         self.printer = config.get_printer()
         self.reactor = self.printer.get_reactor()
-        
+        self.pause_resume = self.printer.lookup_object("pause_resume")
+        self.print_stats = self.printer.lookup_object("print_stats", None)
+        self.toolhead = self.printer.lookup_object("toolhead", None)
+
 
         # Hardware object collections
         self.filament_groups: Dict[str, Any] = {}  # Group name -> FilamentGroup object
@@ -463,13 +513,14 @@ class OAMSManager:
             0.0,
             CLOG_DWELL_MAX - sensitivity_scale * dwell_span,
         )
+        self.stuck_spool_dwell_time: float = max(0.0, self.clog_dwell_time * 0.5)
         self.clog_retraction_tolerance_mm: float = max(
             0.0,
             CLOG_RETRACTION_TOLERANCE_MM,
         )
 
         logging.debug(
-            "OAMS: clog detection sensitivity %.2f -> window %.1fmm, encoder slack %.1f, pressure offset %.2f, dwell %.1fs",
+            "OAMS: clog detection sensitivity %.2f -> window %.1fmm, encoder slack %.1f, pressure window +/-%.2f, dwell %.1fs",
             self.clog_sensitivity,
             self.clog_extruder_window_mm,
             self.clog_encoder_delta_limit,
@@ -484,6 +535,7 @@ class OAMSManager:
         self._canonical_group_by_lane: Dict[str, str] = {}
         self._lane_unit_map: Dict[str, str] = {}
         self._lane_by_location: Dict[Tuple[str, int], str] = {}
+        self._lane_direction_cache: Dict[Tuple[str, int], int] = {}
 
         
         # Initialize hardware collections
@@ -492,6 +544,12 @@ class OAMSManager:
         
         # Register with printer and setup event handlers
         self.printer.register_event_handler("klippy:ready", self.handle_ready)
+        self.printer.register_event_handler(
+            "gcode:command_AFC_RESUME", self._handle_resume_command
+        )
+        self.printer.register_event_handler(
+            "gcode:command_RESUME", self._handle_resume_command
+        )
         self.printer.add_object("oams_manager", self)
         self.register_commands()
         
@@ -541,15 +599,28 @@ class OAMSManager:
         """
         for fps_name, fps_state in self.current_state.fps_state.items():
             fps_state.current_group, current_oams, fps_state.current_spool_idx = self.determine_current_loaded_group(fps_name)
-            
+
             if current_oams is not None:
                 fps_state.current_oams = current_oams.name
             else:
                 fps_state.current_oams = None
-                
+
             if fps_state.current_oams is not None and fps_state.current_spool_idx is not None:
                 fps_state.state_name = FPSLoadState.LOADED
                 fps_state.since = self.reactor.monotonic()
+                direction = self._apply_cached_lane_direction(fps_state)
+                fps_state.following = False
+                fps_state.last_follower_enable_time = 0.0
+                self._ensure_follower_active(
+                    fps_state,
+                    reason="detected loaded state during startup",
+                    preferred_direction=direction,
+                    force=True,
+                )
+            else:
+                fps_state.following = False
+                fps_state.last_follower_enable_time = 0.0
+                self._cancel_pending_follower_assertion(fps_state)
         
     def handle_ready(self) -> None:
         """
@@ -657,6 +728,7 @@ class OAMSManager:
         for _, fps_state in self.current_state.fps_state.items():
             fps_state.encoder_samples.clear()
             fps_state.reset_clog_tracker()
+            self._clear_stuck_spool_state(fps_state)
         for _, oam in self.oams.items():
             oam.clear_errors()
         self.determine_state()
@@ -695,11 +767,20 @@ class OAMSManager:
         if fps_state.state_name == "UNLOADING":
             gcmd.respond_info(f"FPS {fps_name} is currently unloading a spool")
             return
-        self.oams[fps_state.current_oams].set_oams_follower(enable, direction)
-        fps_state.following = enable
-        fps_state.direction = direction
-        fps_state.encoder = self.oams[fps_state.current_oams].encoder_clicks
-        fps_state.current_spool_idx = self.oams[fps_state.current_oams].current_spool
+        hardware = self.oams[fps_state.current_oams]
+        hardware.set_oams_follower(enable, direction)
+        fps_state.following = bool(enable)
+        if direction in (0, 1):
+            fps_state.direction = direction
+        fps_state.last_follower_enable_time = (
+            self.reactor.monotonic() if fps_state.following else 0.0
+        )
+        if not fps_state.following:
+            self._cancel_pending_follower_assertion(fps_state)
+        fps_state.encoder = hardware.encoder_clicks
+        fps_state.current_spool_idx = hardware.current_spool
+        if direction in (0, 1):
+            self._remember_lane_direction(fps_state, direction)
         return
     
 
@@ -739,6 +820,72 @@ class OAMSManager:
             for oam, bay_index in group.bays:
                 mapping[(oam.name, bay_index)] = lane_name
         self._lane_by_location = mapping
+
+    def _lane_direction_key(
+        self,
+        oams_name: Optional[str],
+        spool_idx: Optional[int],
+    ) -> Optional[Tuple[str, int]]:
+        """Return a stable cache key for an OAMS lane."""
+
+        if oams_name is None or spool_idx is None:
+            return None
+        try:
+            index = int(spool_idx)
+        except (TypeError, ValueError):
+            return None
+        return oams_name, index
+
+    def _remember_lane_direction(
+        self,
+        fps_state: 'FPSState',
+        direction: Optional[int],
+        *,
+        oams_name: Optional[str] = None,
+        spool_idx: Optional[int] = None,
+    ) -> None:
+        """Persist the preferred follower direction for the provided lane."""
+
+        if direction not in (0, 1):
+            return
+
+        key = self._lane_direction_key(
+            oams_name if oams_name is not None else fps_state.current_oams,
+            spool_idx if spool_idx is not None else fps_state.current_spool_idx,
+        )
+        if key is None:
+            return
+
+        self._lane_direction_cache[key] = int(direction)
+
+    def _apply_cached_lane_direction(
+        self,
+        fps_state: 'FPSState',
+        default: Optional[int] = None,
+        *,
+        oams_name: Optional[str] = None,
+        spool_idx: Optional[int] = None,
+    ) -> int:
+        """Restore cached follower orientation for the provided lane."""
+
+        key = self._lane_direction_key(
+            oams_name if oams_name is not None else fps_state.current_oams,
+            spool_idx if spool_idx is not None else fps_state.current_spool_idx,
+        )
+        direction = None
+        if key is not None:
+            direction = self._lane_direction_cache.get(key)
+
+        if direction not in (0, 1):
+            if default in (0, 1):
+                direction = default
+            elif fps_state.direction in (0, 1):
+                direction = fps_state.direction
+            else:
+                direction = 1
+
+        fps_state.direction = int(direction)
+        return fps_state.direction
 
     def _ensure_afc_lane_cache(self, afc) -> None:
         """Capture the canonical AFC lane mapping when AFC is available."""
@@ -1107,9 +1254,13 @@ class OAMSManager:
         fps_state.encoder_samples.clear()
         fps_state.reset_clog_tracker()
 
-    def _nudge_filament_before_retry(self, oams, direction: int = 1,
-
-                                     duration: Optional[float] = None) -> None:
+    def _nudge_filament_before_retry(
+        self,
+        oams,
+        direction: int = 1,
+        duration: Optional[float] = None,
+        fps_state: Optional['FPSState'] = None,
+    ) -> None:
         """Briefly move the filament to relieve tension before retrying."""
         if duration is None:
             duration = globals().get("UNLOAD_RETRY_NUDGE_TIME", 0.5)
@@ -1126,6 +1277,10 @@ class OAMSManager:
                 duration,
             )
             oams.set_oams_follower(1, direction)
+            if fps_state is not None:
+                fps_state.following = True
+                fps_state.direction = direction
+                fps_state.last_follower_enable_time = self.reactor.monotonic()
             enable_sent = True
             self.reactor.pause(self.reactor.monotonic() + duration)
         except Exception:
@@ -1142,10 +1297,16 @@ class OAMSManager:
                         "OAMS: Failed to stop follower on %s after nudge",
                         getattr(oams, "name", "unknown"),
                     )
+                if fps_state is not None:
+                    fps_state.following = False
+                    fps_state.last_follower_enable_time = 0.0
 
 
     def _assist_retry_with_extruder(
-        self, fps_name: str, oams
+        self,
+        fps_name: str,
+        oams,
+        fps_state: Optional['FPSState'] = None,
     ) -> Optional[Callable[[], None]]:
         """Retract filament with the extruder prior to an unload retry.
 
@@ -1241,6 +1402,7 @@ class OAMSManager:
         follower_enabled = False
         move_queued = False
         wait_callback: Optional[Callable[[], None]] = None
+        previous_direction = fps_state.direction if fps_state is not None else None
 
         def disable_follower():
             nonlocal follower_enabled
@@ -1254,6 +1416,11 @@ class OAMSManager:
                     )
                 finally:
                     follower_enabled = False
+                    if fps_state is not None:
+                        fps_state.following = False
+                        fps_state.last_follower_enable_time = 0.0
+                        if previous_direction in (0, 1):
+                            fps_state.direction = previous_direction
 
         extruder_name = getattr(extruder, "name", getattr(fps, "extruder_name", "extruder"))
         try:
@@ -1266,6 +1433,9 @@ class OAMSManager:
             )
             oams.set_oams_follower(1, 0)
             follower_enabled = True
+            if fps_state is not None:
+                fps_state.following = True
+                fps_state.last_follower_enable_time = self.reactor.monotonic()
             gcode_move.move_with_transform(new_position, speed)
             gcode_move.last_position = new_position
             move_queued = True
@@ -1319,11 +1489,15 @@ class OAMSManager:
         )
 
         self._clear_error_state_for_retry(fps_state, oams)
-        self._nudge_filament_before_retry(oams)
+        self._nudge_filament_before_retry(oams, fps_state=fps_state)
 
         wait_for_assist: Optional[Callable[[], None]] = None
         try:
-            wait_for_assist = self._assist_retry_with_extruder(fps_name, oams)
+            wait_for_assist = self._assist_retry_with_extruder(
+                fps_name,
+                oams,
+                fps_state=fps_state,
+            )
 
         except Exception:
             logging.exception(
@@ -1437,7 +1611,8 @@ class OAMSManager:
         fps_state.current_spool_idx = None
         fps_state.current_oams = None
         fps_state.following = False
-        fps_state.direction = 0
+        fps_state.last_follower_enable_time = 0.0
+        fps_state.direction = None
         fps_state.encoder = oams.encoder_clicks
         fps_state.encoder_samples.clear()
         fps_state.reset_clog_tracker()
@@ -1553,12 +1728,15 @@ class OAMSManager:
         if oams.current_spool is None:
             fps_state.state_name = FPSLoadState.UNLOADED
             fps_state.following = False
-            fps_state.direction = 0
+            fps_state.last_follower_enable_time = 0.0
+            fps_state.direction = None
             fps_state.current_group = None
             fps_state.current_spool_idx = None
             fps_state.since = self.reactor.monotonic()
             self.current_group = None
             fps_state.reset_clog_tracker()
+            fps_state.reset_stuck_spool_state()
+            self._cancel_pending_follower_assertion(fps_state)
             return True, "Spool already unloaded"
 
         fps_state.state_name = FPSLoadState.UNLOADING
@@ -1566,6 +1744,7 @@ class OAMSManager:
         fps_state.since = self.reactor.monotonic()
         fps_state.current_oams = oams.name
         fps_state.current_spool_idx = oams.current_spool
+        self._cancel_pending_follower_assertion(fps_state)
 
         success, message = oams.unload_spool()
 
@@ -1587,14 +1766,18 @@ class OAMSManager:
                 message = retry_message
 
         if success:
+            self._clear_stuck_spool_state(fps_state, restore_following=False)
+
             fps_state.state_name = FPSLoadState.UNLOADED
             fps_state.following = False
-            fps_state.direction = 0
+            fps_state.last_follower_enable_time = 0.0
+            fps_state.direction = None
             fps_state.since = self.reactor.monotonic()
             fps_state.current_group = None
             fps_state.current_spool_idx = None
             self.current_group = None
             fps_state.reset_clog_tracker()
+            self._cancel_pending_follower_assertion(fps_state)
             return True, message
 
         fps_state.state_name = FPSLoadState.LOADED
@@ -1668,6 +1851,22 @@ class OAMSManager:
         )
         return False, retry_message
 
+    def _reset_failed_load_state(self, fps_state: 'FPSState') -> None:
+        """Return an FPS state to an unloaded baseline after a failed load."""
+
+        fps_state.state_name = FPSLoadState.UNLOADED
+        fps_state.current_group = None
+        fps_state.current_spool_idx = None
+        fps_state.current_oams = None
+        fps_state.following = False
+        fps_state.last_follower_enable_time = 0.0
+        fps_state.direction = None
+        fps_state.encoder = None
+        fps_state.encoder_samples.clear()
+        fps_state.reset_clog_tracker()
+        fps_state.since = self.reactor.monotonic()
+        self._cancel_pending_follower_assertion(fps_state)
+
     def _load_filament_for_group(self, group_name: str) -> Tuple[bool, str]:
         """Load filament for the provided filament group."""
         if group_name not in self.filament_groups:
@@ -1679,36 +1878,119 @@ class OAMSManager:
 
         fps_state = self.current_state.fps_state[fps_name]
 
+        attempted_locations: List[str] = []
+        last_failure_message: Optional[str] = None
+
+        max_attempts = 2
+
+        self._cancel_pending_follower_assertion(fps_state)
+
         for (oam, bay_index) in self.filament_groups[group_name].bays:
             if not oam.is_bay_ready(bay_index):
                 continue
 
-            fps_state.state_name = FPSLoadState.LOADING
-            fps_state.encoder = oam.encoder_clicks
-            fps_state.since = self.reactor.monotonic()
-            fps_state.current_oams = oam.name
-            fps_state.current_spool_idx = bay_index
+            attempted_locations.append(
+                f"{getattr(oam, 'name', 'unknown')} bay {bay_index}"
+            )
 
-            success, message = oam.load_spool(bay_index)
-
-            if success:
-                fps_state.current_group = group_name
+            for attempt_index in range(max_attempts):
+                attempt_number = attempt_index + 1
+                fps_state.state_name = FPSLoadState.LOADING
+                fps_state.encoder_samples.clear()
+                fps_state.encoder = oam.encoder_clicks
+                fps_state.since = self.reactor.monotonic()
                 fps_state.current_oams = oam.name
                 fps_state.current_spool_idx = bay_index
-                fps_state.state_name = FPSLoadState.LOADED
-                fps_state.since = self.reactor.monotonic()
-                fps_state.following = False
-                fps_state.direction = 1
-                self.current_group = group_name
-                fps_state.reset_clog_tracker()
-                return True, message
 
-            fps_state.state_name = FPSLoadState.UNLOADED
-            fps_state.current_group = None
-            fps_state.current_spool_idx = None
-            fps_state.current_oams = None
-            fps_state.reset_clog_tracker()
-            return False, message
+                success, message = oam.load_spool(bay_index)
+                if success:
+                    fps_state.current_group = group_name
+                    fps_state.current_oams = oam.name
+                    fps_state.current_spool_idx = bay_index
+                    fps_state.state_name = FPSLoadState.LOADED
+                    fps_state.since = self.reactor.monotonic()
+                    self.current_group = group_name
+                    fps_state.encoder_samples.clear()
+                    fps_state.reset_clog_tracker()
+                    self._clear_stuck_spool_state(
+                        fps_state,
+                        restore_following=False,
+                    )
+                    direction = self._apply_cached_lane_direction(
+                        fps_state,
+                        oams_name=oam.name,
+                        spool_idx=bay_index,
+                    )
+                    fps_state.following = False
+                    fps_state.last_follower_enable_time = 0.0
+                    self._ensure_follower_active(
+                        fps_state,
+                        reason=f"spool load for group {group_name}",
+                        preferred_direction=direction,
+                        force=True,
+                    )
+                    return True, message
+
+                failure_reason = message or "Unknown load failure"
+                logging.warning(
+                    "OAMS: Failed load attempt %s for group %s from %s bay %s: %s",
+                    attempt_number,
+                    group_name,
+                    getattr(oam, "name", "unknown"),
+                    bay_index,
+                    failure_reason,
+                )
+
+                retry_success, retry_message = self._attempt_unload_retry(
+                    fps_name,
+                    fps_state,
+                    oam,
+                    message,
+                )
+                if retry_success:
+                    logging.info(
+                        "OAMS: Cleared stalled load on %s bay %s before retrying",
+                        getattr(oam, "name", "unknown"),
+                        bay_index,
+                    )
+                elif retry_message:
+                    logging.warning(
+                        "OAMS: Automatic unload retry failed for %s bay %s: %s",
+                        getattr(oam, "name", "unknown"),
+                        bay_index,
+                        retry_message,
+                    )
+
+                if hasattr(oam, "clear_errors"):
+                    try:
+                        oam.clear_errors()
+                    except Exception:
+                        logging.exception(
+                            "OAMS: Failed to clear errors on %s before retry",
+                            getattr(oam, "name", "unknown"),
+                        )
+
+                self._clear_stuck_spool_state(fps_state, restore_following=False)
+
+                self._reset_failed_load_state(fps_state)
+                self.current_group = None
+
+                last_failure_message = failure_reason
+
+                if attempt_index < max_attempts - 1:
+                    continue
+                break
+
+        if attempted_locations:
+            attempts_summary = ", ".join(attempted_locations)
+            detail = last_failure_message or "No detailed error provided"
+            final_message = (
+                "All ready bays failed to load for group "
+                f"{group_name} after automatic retries "
+                f"(attempted: {attempts_summary}). Last error: {detail}"
+            )
+            logging.error("OAMS: %s", final_message)
+            return False, final_message
 
         return False, f"No spool available for group {group_name}"
 
@@ -1756,13 +2038,258 @@ class OAMSManager:
 
         
     def _pause_printer_message(self, message):
+        """Report an error and pause the printer when it is safe to do so."""
+
         logging.info(f"OAMS: {message}")
+
         gcode = self.printer.lookup_object("gcode")
-        message = f"Print has been paused: {message}"
-        gcode.run_script(f"M118 {message}")
-        gcode.run_script(f"M114 {message}")
-        gcode.run_script("PAUSE")
-        
+        formatted = f"Print has been paused: {message}"
+
+        try:
+            gcode.run_script(f"M118 {formatted}")
+        except Exception:
+            logging.exception("OAMS: Failed to send pause notification via M118")
+
+        eventtime = self.reactor.monotonic()
+        should_pause = True
+
+        pause_resume = self.pause_resume
+        if pause_resume is not None:
+            try:
+                is_paused = bool(
+                    pause_resume.get_status(eventtime).get("is_paused")
+                )
+                if is_paused:
+                    should_pause = False
+            except Exception:
+                logging.exception("OAMS: Failed to query pause state before pausing")
+                should_pause = False
+
+        idle_timeout = self.printer.lookup_object("idle_timeout", None)
+        if should_pause and idle_timeout is not None:
+            try:
+                idle_state = idle_timeout.get_status(eventtime).get("state")
+                should_pause = idle_state == "Printing"
+            except Exception:
+                logging.exception(
+                    "OAMS: Failed to query idle timeout state before pausing"
+                )
+                should_pause = False
+
+        if should_pause and self.print_stats is not None:
+            try:
+                stats_state = self.print_stats.get_status(eventtime).get("state")
+                should_pause = stats_state == "printing"
+            except Exception:
+                logging.exception(
+                    "OAMS: Failed to query print stats state before pausing"
+                )
+                should_pause = False
+
+        if should_pause and self.toolhead is not None:
+            try:
+                homed_axes = self.toolhead.get_status(eventtime).get(
+                    "homed_axes", ""
+                )
+            except Exception:
+                logging.exception(
+                    "OAMS: Failed to query homed axes before pausing"
+                )
+                homed_axes = ""
+
+            if isinstance(homed_axes, (list, tuple, set)):
+                axes = "".join(homed_axes)
+            else:
+                axes = str(homed_axes)
+
+            if not all(axis in axes for axis in "xyz"):
+                should_pause = False
+
+        if not should_pause:
+            return
+
+        try:
+            gcode.run_script(f"M114 {formatted}")
+        except Exception:
+            logging.exception("OAMS: Failed to report position before pausing")
+
+        try:
+            gcode.run_script("PAUSE")
+        except Exception:
+            logging.exception("OAMS: Failed to execute PAUSE command")
+
+    def _ensure_follower_active(
+        self,
+        fps_state: 'FPSState',
+        reason: Optional[str] = None,
+        preferred_direction: Optional[int] = None,
+        force: bool = False,
+    ) -> None:
+        """Enable the follower for the provided FPS if it isn't already running."""
+
+        oams_name = fps_state.current_oams
+        if oams_name is None:
+            return
+
+        oams = self.oams.get(oams_name)
+        if oams is None or not hasattr(oams, "set_oams_follower"):
+            return
+
+        now = self.reactor.monotonic()
+
+        spool_idx = (
+            fps_state.current_spool_idx
+            if fps_state.current_spool_idx is not None
+            else fps_state.stuck_spool_last_spool_idx
+        )
+
+        direction = preferred_direction if preferred_direction in (0, 1) else None
+        if direction is None:
+            if fps_state.direction in (0, 1):
+                direction = fps_state.direction
+            elif fps_state.stuck_spool_restore_direction in (0, 1):
+                direction = fps_state.stuck_spool_restore_direction
+
+        if direction not in (0, 1):
+            direction = 1
+
+        fps_state.stuck_spool_restore_direction = direction
+
+        suffix = f" ({reason})" if reason else ""
+        spool_display = spool_idx if spool_idx is not None else "?"
+        try:
+            oams.set_oams_follower(1, direction)
+            fps_state.following = True
+            fps_state.direction = direction
+            fps_state.last_follower_enable_time = now
+            self._remember_lane_direction(
+                fps_state,
+                direction,
+                oams_name=oams_name,
+                spool_idx=spool_idx,
+            )
+            logging.info(
+                "OAMS: Enabled follower on %s spool %s%s",
+                getattr(oams, "name", oams_name),
+                spool_display,
+                suffix,
+            )
+        except Exception:
+            logging.exception(
+                "OAMS: Failed to enable follower on %s spool %s%s",
+                getattr(oams, "name", oams_name),
+                spool_display,
+                suffix,
+            )
+
+    def _cancel_pending_follower_assertion(self, fps_state: 'FPSState') -> None:
+        """Clear any pending follower keepalive bookkeeping."""
+
+        fps_state.pending_follower_enable_timer = None
+
+    def _clear_stuck_spool_state(
+        self,
+        fps_state: 'FPSState',
+        restore_following: bool = True,
+    ) -> None:
+        """Clear any latched stuck-spool indicators for the provided FPS."""
+
+        self._cancel_pending_follower_assertion(fps_state)
+
+        had_latched_state = (
+            fps_state.stuck_spool_active
+            or fps_state.stuck_spool_led_asserted
+            or fps_state.stuck_spool_should_restore_follower
+            or fps_state.stuck_spool_last_oams is not None
+            or fps_state.stuck_spool_last_spool_idx is not None
+        )
+
+        if not had_latched_state:
+            fps_state.reset_stuck_spool_state()
+            return
+
+        oams_name = fps_state.stuck_spool_last_oams
+        spool_idx = fps_state.stuck_spool_last_spool_idx
+        stored_oams = self.oams.get(oams_name) if oams_name is not None else None
+
+        if fps_state.stuck_spool_led_asserted and stored_oams is not None and spool_idx is not None:
+            try:
+                stored_oams.set_led_error(spool_idx, 0)
+            except Exception:
+                logging.exception(
+                    "OAMS: Failed to clear stuck spool LED on %s spool %s",
+                    getattr(stored_oams, "name", oams_name),
+                    spool_idx,
+                )
+
+        active_oams_name = fps_state.current_oams or oams_name
+        active_oams = (
+            self.oams.get(active_oams_name)
+            if active_oams_name is not None
+            else stored_oams
+        )
+
+        cleared_ids = set()
+        for unit, unit_name in (
+            (active_oams, active_oams_name),
+            (stored_oams, oams_name),
+        ):
+            unit_id = id(unit) if unit is not None else None
+            if (
+                unit is None
+                or unit_id in cleared_ids
+                or not hasattr(unit, "clear_errors")
+            ):
+                continue
+            try:
+                unit.clear_errors()
+            except Exception:
+                logging.exception(
+                    "OAMS: Failed to clear stuck spool error on %s",
+                    getattr(unit, "name", unit_name),
+                )
+            cleared_ids.add(unit_id)
+
+        should_restore = (
+            restore_following
+            and fps_state.stuck_spool_should_restore_follower
+            and fps_state.state_name == FPSLoadState.LOADED
+            and active_oams is not None
+            and hasattr(active_oams, "set_oams_follower")
+        )
+
+        if should_restore:
+            direction = fps_state.stuck_spool_restore_direction
+            if direction not in (0, 1):
+                direction = fps_state.direction if fps_state.direction in (0, 1) else 1
+            self._ensure_follower_active(
+                fps_state,
+                reason="stuck spool recovery",
+                preferred_direction=direction,
+                force=True,
+            )
+        fps_state.reset_stuck_spool_state()
+
+    def _handle_resume_command(self, *args, **kwargs) -> None:
+        """React to resume commands so stuck-spool state clears immediately."""
+
+        if not self.ready:
+            return
+
+        self.reactor.register_callback(self._recover_after_resume)
+
+    def _recover_after_resume(self, eventtime):
+        for fps_state in self.current_state.fps_state.values():
+            if (
+                fps_state.stuck_spool_active
+                or fps_state.stuck_spool_led_asserted
+                or fps_state.stuck_spool_should_restore_follower
+            ):
+                self._clear_stuck_spool_state(fps_state)
+        if not self.monitor_timers:
+            self.start_monitors()
+        return self.reactor.NEVER
+
     def _monitor_unload_speed_for_fps(self, fps_name):
         def _monitor_unload_speed(self, eventtime):
             #logging.info("OAMS: Monitoring unloading speed state: %s" % self.current_state.name)
@@ -1786,6 +2313,11 @@ class OAMSManager:
         return partial(_monitor_unload_speed, self)
     
     def _monitor_load_speed_for_fps(self, fps_name):
+        idle_timeout = self.printer.lookup_object("idle_timeout")
+        pause_resume = self.pause_resume
+        print_stats = self.print_stats
+        toolhead = self.toolhead
+
         def _monitor_load_speed(self, eventtime):
             #logging.info("OAMS: Monitoring loading speed state: %s" % self.current_state.name)
             fps_state = self.current_state.fps_state[fps_name]
@@ -1819,16 +2351,305 @@ class OAMSManager:
                                     getattr(oams, "name", fps_state.current_oams),
                                     spool_idx,
                                 )
-                        self._pause_printer_message("Printer paused because the loading speed of the moving filament was too low")
-                        self.stop_monitors()
-                        return self.printer.get_reactor().NEVER
+                        should_pause = False
+                        is_paused = False
+
+                        if pause_resume is not None:
+                            try:
+                                is_paused = bool(
+                                    pause_resume.get_status(eventtime).get("is_paused")
+                                )
+                            except Exception:
+                                logging.exception(
+                                    "OAMS: Failed to query pause state for load monitor"
+                                )
+
+                        if not is_paused and idle_timeout is not None:
+                            try:
+                                idle_status = idle_timeout.get_status(eventtime)
+                                should_pause = idle_status.get("state") == "Printing"
+                            except Exception:
+                                logging.exception(
+                                    "OAMS: Failed to query idle timeout state for load monitor"
+                                )
+                                should_pause = False
+
+                        if should_pause and print_stats is not None:
+                            try:
+                                stats_state = print_stats.get_status(eventtime).get("state")
+                                should_pause = stats_state == "printing"
+                            except Exception:
+                                logging.exception(
+                                    "OAMS: Failed to query print stats for load monitor"
+                                )
+                                should_pause = False
+
+                        if should_pause and toolhead is not None:
+                            try:
+                                homed_axes = toolhead.get_status(eventtime).get(
+                                    "homed_axes", ""
+                                )
+                            except Exception:
+                                logging.exception(
+                                    "OAMS: Failed to query homed axes for load monitor"
+                                )
+                                homed_axes = ""
+
+                            if isinstance(homed_axes, (list, tuple, set)):
+                                axes = "".join(homed_axes)
+                            else:
+                                axes = str(homed_axes)
+
+                            if not all(axis in axes for axis in "xyz"):
+                                should_pause = False
+
+                        message = (
+                            "Printer paused because the loading speed of the moving filament was too low"
+                        )
+
+                        if should_pause:
+                            self._pause_printer_message(message)
+                            self.stop_monitors()
+                            return self.printer.get_reactor().NEVER
+
+                        logging.error("OAMS: %s", message)
+                        try:
+                            gcode = self.printer.lookup_object("gcode")
+                            if gcode is not None:
+                                gcode.respond_info(f"OAMS: {message}")
+                        except Exception:
+                            logging.exception(
+                                "OAMS: Failed to report stalled load message to console"
+                            )
                     return eventtime + MONITOR_ENCODER_PERIOD
             return eventtime + MONITOR_ENCODER_PERIOD
         return partial(_monitor_load_speed, self)
 
 
+    def _monitor_follower_state_for_fps(self, fps_name: str):
+        def _monitor_follower_state(self, eventtime):
+            fps_state = self.current_state.fps_state.get(fps_name)
+            if fps_state is None:
+                return eventtime + FOLLOWER_RECOVERY_RETRY_INTERVAL
+
+            if fps_state.state_name != FPSLoadState.LOADED:
+                self._cancel_pending_follower_assertion(fps_state)
+                return eventtime + FOLLOWER_RECOVERY_RETRY_INTERVAL
+
+            if fps_state.current_oams is None or fps_state.current_spool_idx is None:
+                return eventtime + FOLLOWER_RECOVERY_RETRY_INTERVAL
+
+            if fps_state.stuck_spool_active or fps_state.stuck_spool_should_restore_follower:
+                return eventtime + FOLLOWER_RECOVERY_RETRY_INTERVAL
+
+            direction = fps_state.direction if fps_state.direction in (0, 1) else None
+            if direction is None and fps_state.stuck_spool_restore_direction in (0, 1):
+                direction = fps_state.stuck_spool_restore_direction
+            if direction is None:
+                direction = self._apply_cached_lane_direction(fps_state)
+            if direction not in (0, 1):
+                direction = 1
+
+            self._ensure_follower_active(
+                fps_state,
+                reason="loaded lane follower keepalive",
+                preferred_direction=direction,
+                force=True,
+            )
+
+            return eventtime + FOLLOWER_RECOVERY_RETRY_INTERVAL
+
+        return partial(_monitor_follower_state, self)
+
+
+    def _monitor_stuck_spool_for_fps(self, fps_name: str):
+        idle_timeout = self.printer.lookup_object("idle_timeout")
+        pause_resume = self.pause_resume
+        print_stats = self.print_stats
+        runout_monitors = self.runout_monitors
+
+        def _monitor_stuck_spool(self, eventtime):
+            fps_state = self.current_state.fps_state.get(fps_name)
+            fps = self.fpss.get(fps_name)
+            if fps_state is None or fps is None:
+                return eventtime + self.clog_monitor_period
+
+            try:
+                is_paused = bool(pause_resume.get_status(eventtime).get("is_paused"))
+            except Exception:
+                logging.exception("OAMS: Failed to query pause state for stuck spool monitor")
+                is_paused = False
+
+            if fps_state.stuck_spool_active:
+                spool_changed = (
+                    fps_state.current_oams != fps_state.stuck_spool_last_oams
+                    or fps_state.current_spool_idx != fps_state.stuck_spool_last_spool_idx
+                    or fps_state.current_oams is None
+                    or fps_state.current_spool_idx is None
+                )
+                if spool_changed:
+                    self._clear_stuck_spool_state(fps_state, restore_following=False)
+                    return eventtime + self.clog_monitor_period
+                if is_paused:
+                    return eventtime + self.clog_monitor_period
+                self._clear_stuck_spool_state(fps_state)
+
+            status = idle_timeout.get_status(eventtime)
+            is_printing = status.get("state") == "Printing"
+
+            all_axes_homed = True
+            if self.toolhead is not None:
+                try:
+                    homed_axes = self.toolhead.get_status(eventtime).get(
+                        "homed_axes", ""
+                    )
+                except Exception:
+                    logging.exception(
+                        "OAMS: Failed to query homed axes for stuck spool monitor"
+                    )
+                    homed_axes = ""
+
+                if isinstance(homed_axes, (list, tuple, set)):
+                    axes = "".join(homed_axes)
+                else:
+                    axes = str(homed_axes)
+
+                all_axes_homed = all(axis in axes for axis in "xyz")
+
+            if not all_axes_homed:
+                fps_state.stuck_spool_start_time = None
+                return eventtime + self.clog_monitor_period
+
+            if is_printing and print_stats is not None:
+                try:
+                    stats_state = print_stats.get_status(eventtime).get("state")
+                except Exception:
+                    logging.exception(
+                        "OAMS: Failed to query print stats for stuck spool monitor"
+                    )
+                    stats_state = None
+                is_printing = stats_state == "printing"
+
+            if fps_state.state_name != FPSLoadState.LOADED:
+                fps_state.stuck_spool_start_time = None
+                return eventtime + self.clog_monitor_period
+
+            if fps_state.current_oams is None or fps_state.current_spool_idx is None:
+                fps_state.stuck_spool_start_time = None
+                return eventtime + self.clog_monitor_period
+
+            oams = self.oams.get(fps_state.current_oams)
+            if oams is None:
+                fps_state.stuck_spool_start_time = None
+                return eventtime + self.clog_monitor_period
+
+            monitor = runout_monitors.get(fps_name) if runout_monitors is not None else None
+            if monitor is not None and getattr(monitor, "state", None) != OAMSRunoutState.MONITORING:
+                fps_state.stuck_spool_start_time = None
+                return eventtime + self.clog_monitor_period
+
+            hub_values = getattr(oams, "hub_hes_value", None)
+            if (
+                hub_values is not None
+                and fps_state.current_spool_idx is not None
+                and 0 <= fps_state.current_spool_idx < len(hub_values)
+            ):
+                try:
+                    has_filament = bool(hub_values[fps_state.current_spool_idx])
+                except Exception:
+                    logging.exception(
+                        "OAMS: Failed to query hub sensor state for stuck spool monitor"
+                    )
+                    has_filament = True
+                if not has_filament:
+                    fps_state.stuck_spool_start_time = None
+                    return eventtime + self.clog_monitor_period
+
+            if not is_printing:
+                fps_state.stuck_spool_start_time = None
+                return eventtime + self.clog_monitor_period
+
+            pressure = float(
+                getattr(oams, "fps_value", getattr(fps, "fps_value", 0.0)) or 0.0
+            )
+            now = self.reactor.monotonic()
+
+            if pressure > STUCK_SPOOL_PRESSURE_TRIGGER:
+                fps_state.stuck_spool_start_time = None
+                return eventtime + self.clog_monitor_period
+
+            if fps_state.stuck_spool_start_time is None:
+                fps_state.stuck_spool_start_time = now
+                return eventtime + self.clog_monitor_period
+
+            elapsed = now - fps_state.stuck_spool_start_time
+            if elapsed < self.stuck_spool_dwell_time:
+                return eventtime + self.clog_monitor_period
+
+            fps_state.stuck_spool_active = True
+            fps_state.stuck_spool_last_oams = fps_state.current_oams
+            fps_state.stuck_spool_last_spool_idx = fps_state.current_spool_idx
+            fps_state.stuck_spool_start_time = None
+            fps_state.stuck_spool_should_restore_follower = True
+            direction = (
+                fps_state.direction if fps_state.direction in (0, 1) else 1
+            )
+            fps_state.stuck_spool_restore_direction = direction
+            self._cancel_pending_follower_assertion(fps_state)
+            if hasattr(oams, "set_oams_follower"):
+                try:
+                    oams.set_oams_follower(0, direction)
+                    fps_state.following = False
+                    fps_state.last_follower_enable_time = 0.0
+                    fps_state.direction = direction
+                    logging.info(
+                        "OAMS: Disabled follower on %s spool %s due to stuck spool detection",
+                        getattr(oams, "name", fps_state.current_oams),
+                        fps_state.current_spool_idx,
+                    )
+                except Exception:
+                    logging.exception(
+                        "OAMS: Failed to stop follower after stuck spool on %s spool %s",
+                        getattr(oams, "name", fps_state.current_oams),
+                        fps_state.current_spool_idx,
+                    )
+            if fps_state.current_spool_idx is not None:
+                try:
+                    oams.set_led_error(fps_state.current_spool_idx, 1)
+                    fps_state.stuck_spool_led_asserted = True
+                except Exception:
+                    logging.exception(
+                        "OAMS: Failed to set stuck spool LED on %s spool %s",
+                        getattr(oams, "name", fps_state.current_oams),
+                        fps_state.current_spool_idx,
+                    )
+            group = fps_state.current_group or fps_name
+            trigger_detail = (
+                f"pressure {pressure:.2f} for {elapsed:.1f}s"
+            )
+
+            logging.error(
+                "OAMS: Stuck spool detected on %s (spool %s) due to %s",
+                group,
+                fps_state.current_spool_idx,
+                trigger_detail,
+            )
+            self._pause_printer_message(
+                "Spool appears stuck on %s spool %s (%s)"
+                % (group, fps_state.current_spool_idx, trigger_detail)
+            )
+            return eventtime + self.clog_monitor_period
+
+            return eventtime + self.clog_monitor_period
+
+        return partial(_monitor_stuck_spool, self)
+
+
     def _monitor_clog_for_fps(self, fps_name: str):
         idle_timeout = self.printer.lookup_object("idle_timeout")
+        pause_resume = self.pause_resume
+        print_stats = self.print_stats
+        toolhead = self.toolhead
 
         def _monitor_clog(self, eventtime):
             if not self.clog_detection_enabled:
@@ -1839,13 +2660,51 @@ class OAMSManager:
             if fps_state is None or fps is None:
                 return eventtime + self.clog_monitor_period
 
-            status = idle_timeout.get_status(eventtime)
-            is_printing = status.get("state") == "Printing"
-            if not is_printing or fps_state.state_name != FPSLoadState.LOADED:
+            is_paused = False
+            if pause_resume is not None:
+                try:
+                    is_paused = bool(pause_resume.get_status(eventtime).get("is_paused"))
+                except Exception:
+                    logging.exception("OAMS: Failed to query pause state for clog monitor")
+                    is_paused = False
+
+            if is_paused or fps_state.state_name != FPSLoadState.LOADED:
                 fps_state.reset_clog_tracker()
                 return eventtime + self.clog_monitor_period
 
-            if fps_state.current_oams is None:
+            status = idle_timeout.get_status(eventtime)
+            is_printing = status.get("state") == "Printing"
+
+            if is_printing and print_stats is not None:
+                try:
+                    stats_state = print_stats.get_status(eventtime).get("state")
+                except Exception:
+                    logging.exception("OAMS: Failed to query print stats for clog monitor")
+                    stats_state = None
+                is_printing = stats_state == "printing"
+
+            all_axes_homed = True
+            if toolhead is not None:
+                try:
+                    homed_axes = toolhead.get_status(eventtime).get("homed_axes", "")
+                except Exception:
+                    logging.exception("OAMS: Failed to query homed axes for clog monitor")
+                    homed_axes = ""
+
+                if isinstance(homed_axes, (list, tuple, set)):
+                    axes = "".join(homed_axes)
+                else:
+                    axes = str(homed_axes)
+
+                all_axes_homed = all(axis in axes for axis in "xyz")
+
+            if (
+                not is_printing
+                or not all_axes_homed
+                or fps_state.current_oams is None
+                or fps_state.current_spool_idx is None
+                or fps_state.stuck_spool_active
+            ):
                 fps_state.reset_clog_tracker()
                 return eventtime + self.clog_monitor_period
 
@@ -1917,9 +2776,18 @@ class OAMSManager:
                 )
                 return eventtime + self.clog_monitor_period
 
+            if encoder_delta >= max(1.0, float(MIN_ENCODER_DIFF)):
+                if not fps_state.clog_encoder_activity:
+                    fps_state.clog_encoder_activity = True
+                    fps_state.clog_start_time = now
+            elif not fps_state.clog_encoder_activity:
+                fps_state.clog_start_time = now
+                return eventtime + self.clog_monitor_period
+
             fps_state.clog_extruder_delta = extruder_delta
             fps_state.clog_encoder_delta = encoder_delta
             fps_state.clog_max_pressure = max(fps_state.clog_max_pressure, pressure)
+            fps_state.clog_min_pressure = min(fps_state.clog_min_pressure, pressure)
             fps_state.clog_last_extruder = float(extruder_position)
             fps_state.clog_last_encoder = encoder_position
 
@@ -1935,20 +2803,32 @@ class OAMSManager:
                 target_pressure = getattr(fps, "fps_target", None)
             if target_pressure is None:
                 target_pressure = getattr(fps, "_set_point", 0.5)
-            pressure_floor = max(0.0, min(1.0, float(target_pressure) + self.clog_pressure_offset))
+            clamped_target = max(0.0, min(1.0, float(target_pressure)))
+            pressure_window = max(0.0, self.clog_pressure_offset)
+            clamped_min_pressure = max(0.0, min(1.0, float(fps_state.clog_min_pressure)))
+            clamped_max_pressure = max(0.0, min(1.0, float(fps_state.clog_max_pressure)))
 
-            if fps_state.clog_max_pressure < pressure_floor:
+            max_deviation = max(
+                abs(clamped_max_pressure - clamped_target),
+                abs(clamped_min_pressure - clamped_target),
+            )
+
+            if pressure_window and max_deviation > pressure_window:
+                return eventtime + self.clog_monitor_period
+            if not pressure_window and max_deviation > 0.0:
                 return eventtime + self.clog_monitor_period
 
             if abs(encoder_delta) > self.clog_encoder_delta_limit:
                 return eventtime + self.clog_monitor_period
 
             logging.error(
-                "OAMS: Clog suspected on %s after %.1fmm extruder advance (encoder %.1f, pressure %.2f)",
+                "OAMS: Clog suspected on %s after %.1fmm extruder advance (encoder %.1f, fps window %.2f-%.2f around %.2f)",
                 fps_name,
                 extruder_delta,
                 encoder_delta,
-                fps_state.clog_max_pressure,
+                clamped_min_pressure,
+                clamped_max_pressure,
+                clamped_target,
             )
 
             if fps_state.current_spool_idx is not None:
@@ -1964,13 +2844,15 @@ class OAMSManager:
             self._pause_printer_message(
                 (
                     "Clog suspected on %s: extruder advanced %.1fmm while encoder moved %.1f "
-                    "counts at %.2f pressure"
+                    "counts with FPS %.2f-%.2f around %.2f"
                 )
                 % (
                     fps_name,
                     extruder_delta,
                     encoder_delta,
-                    fps_state.clog_max_pressure,
+                    clamped_min_pressure,
+                    clamped_max_pressure,
+                    clamped_target,
                 )
             )
             fps_state.reset_clog_tracker()
@@ -1988,6 +2870,18 @@ class OAMSManager:
             fps_state.reset_clog_tracker()
             self.monitor_timers.append(reactor.register_timer(self._monitor_unload_speed_for_fps(fps_name), reactor.NOW))
             self.monitor_timers.append(reactor.register_timer(self._monitor_load_speed_for_fps(fps_name), reactor.NOW))
+            self.monitor_timers.append(
+                reactor.register_timer(
+                    self._monitor_follower_state_for_fps(fps_name),
+                    reactor.NOW,
+                )
+            )
+            self.monitor_timers.append(
+                reactor.register_timer(
+                    self._monitor_stuck_spool_for_fps(fps_name),
+                    reactor.NOW,
+                )
+            )
             if self.clog_detection_enabled:
                 self.monitor_timers.append(
                     reactor.register_timer(
@@ -2152,6 +3046,7 @@ class OAMSManager:
                     )
                 finally:
                     fps_state.monitor_load_next_spool_timer = None
+            self._cancel_pending_follower_assertion(fps_state)
         for monitor in self.runout_monitors.values():
             monitor.reset()
         self.runout_monitors = {}


### PR DESCRIPTION
## Summary
- guard `_pause_printer_message` so the PAUSE command only fires when the printer is actively printing and fully homed
- log and surface the notification message without pausing when the printer is idle to avoid Klipper crashes during load retries

## Testing
- python -m compileall klipper_openams/src

------
https://chatgpt.com/codex/tasks/task_e_68d32c5e1b8083269517927f9c332af1