### PR TITLE
Fix Cartographer macro result aggregation

### DIFF
--- a/printer_data/config/AFC/AFC_Extra_Macros.cfg
+++ b/printer_data/config/AFC/AFC_Extra_Macros.cfg
@@ -36,7 +36,7 @@ gcode:
 [gcode_macro _CARTO_CALIBRATE_TOOL_OFFSET]
 gcode:
   {% set tools = printer.toolchanger.tool_numbers %}
-  SET_GCODE_VARIABLE MACRO=_CARTO_CALIBRATE_TOOL_EVALUATE VARIABLE=z_results VALUE="''"
+  SET_GCODE_VARIABLE MACRO=_CARTO_CALIBRATE_TOOL_EVALUATE VARIABLE=z_results VALUE=""
   RESPOND TYPE=command MSG="Calibrating Z offsets for tools"
 
   {% for tool in tools %}
@@ -62,9 +62,12 @@ gcode:
     {% set result = "T" ~ cur_tool|string ~ " gcode_z_offset: " ~ (adjusted_result|round(4)) %}
 
     {% set prev = printer["gcode_macro _CARTO_CALIBRATE_TOOL_EVALUATE"].z_results %}
-    {% set clean_prev = prev.strip("'") %}
-    {% set new_full = (clean_prev + "\\n" + result).strip() %}
-    SET_GCODE_VARIABLE MACRO=_CARTO_CALIBRATE_TOOL_EVALUATE VARIABLE=z_results VALUE="'{ new_full }'"
+    {% if prev %}
+      {% set combined = prev ~ '|' ~ result %}
+    {% else %}
+      {% set combined = result %}
+    {% endif %}
+    SET_GCODE_VARIABLE MACRO=_CARTO_CALIBRATE_TOOL_EVALUATE VARIABLE=z_results VALUE="'{ combined }'"
   {% else %}
     RESPOND TYPE=command MSG="Touch failed for tool {cur_tool}"
   {% endif %}
@@ -73,7 +76,7 @@ gcode:
 variable_z_results: ''
 gcode:
   RESPOND TYPE=command MSG="Z-offsets from Carto using an offset of 0.02 from absolute zero"
-  {% for line in z_results.strip().split('\n') if line %}
+  {% for line in z_results.strip().split('|') if line %}
     RESPOND TYPE=command MSG="{line}"
     G4 P1500
   {% endfor %}


### PR DESCRIPTION
## Summary
- rework the Cartographer Z calibration macros to avoid embedding raw newlines in the stored results
- append results with a safe delimiter and iterate over the aggregated list when reporting offsets

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d4ac13c0e08326b72ef521cdb3928f