### PR TITLE
Prevent stuck spool detection during runout events

### DIFF
--- a/klipper_openams/src/oams_manager.py
+++ b/klipper_openams/src/oams_manager.py
@@ -1757,6 +1757,17 @@ class OAMSManager:
 
                 return eventtime + MONITOR_ENCODER_PERIOD
 
+            monitor = self.runout_monitors.get(fps_name)
+            if monitor and monitor.state in (
+                OAMSRunoutState.DETECTED,
+                OAMSRunoutState.COASTING,
+                OAMSRunoutState.RELOADING,
+            ):
+                fps_state.reset_stuck_spool_state(
+                    preserve_restore=fps_state.stuck_spool_restore_follower
+                )
+                return eventtime + MONITOR_ENCODER_PERIOD
+
             pressure = float(getattr(fps, "fps_value", 0.0))
             now = self.reactor.monotonic()
 


### PR DESCRIPTION
## Summary
- skip stuck spool pressure monitoring while the infinite runout monitor is coasting or reloading
- reset any latched stuck spool state during runout handling to avoid false positives

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d83c5beb488326bb2ac4e5e72e78d2