### PR TITLE
Prevent clog detection during AMS infinite runout transitions

### DIFF
--- a/klipper_openams/src/oams_manager.py
+++ b/klipper_openams/src/oams_manager.py
@@ -1601,6 +1601,20 @@ class OAMSManager:
             except Exception:
                 is_printing = False
 
+            monitor = self.runout_monitors.get(fps_name)
+            if monitor is not None and monitor.state != OAMSRunoutState.MONITORING:
+                if fps_state.clog_active:
+                    try:
+                        oams.set_led_error(fps_state.current_spool_idx, 0)
+                    except Exception:
+                        logging.exception(
+                            "OAMS: Failed to clear clog LED on %s spool %s while runout monitor inactive",
+                            fps_name,
+                            fps_state.current_spool_idx,
+                        )
+                fps_state.reset_clog_tracker()
+                return eventtime + MONITOR_ENCODER_PERIOD
+
             if not is_printing:
                 if fps_state.clog_active:
                     try:


### PR DESCRIPTION
## Summary
- avoid clog detection when the runout monitor is not actively monitoring, covering loading, unloading, and infinite runout states
- clear any latched clog indicator before resetting the tracker during these transitions

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d933c50aec8326b4c3f17975bb7097