### PR TITLE
Improve stuck spool recovery direction handling

### DIFF
--- a/klipper_openams/src/oams_manager.py
+++ b/klipper_openams/src/oams_manager.py
@@ -23,6 +23,8 @@ AFC_DELEGATION_TIMEOUT = 30.0  # seconds to suppress duplicate AFC runout trigge
 
 STUCK_SPOOL_PRESSURE_THRESHOLD = 0.08  # Pressure indicating the spool is no longer feeding
 STUCK_SPOOL_DWELL = 8.0  # Seconds the pressure must remain below the threshold before pausing
+STUCK_SPOOL_RECOVERY_REVERSE_TIME = 2.0  # Interval to reverse follow direction for recovery
+STUCK_SPOOL_RECOVERY_SETTLE_TIME = 0.1  # Delay between stopping and reversing follower
 
 
 CLOG_PRESSURE_TARGET = 0.50
@@ -267,6 +269,7 @@ class FPSState:
     - following: Whether follower mode is active
     - direction: Follower direction (0=forward, 1=reverse)
     - since: Timestamp when current state began
+    - stuck_spool_retry_*: Tracking for automatic recovery attempts
     """
     
     def __init__(self, 
@@ -307,6 +310,13 @@ class FPSState:
         self.stuck_spool_active: bool = False
         self.stuck_spool_restore_follower: bool = False
         self.stuck_spool_restore_direction: int = 1
+        self.stuck_spool_retry_attempted: bool = False
+        self.stuck_spool_retry_active: bool = False
+        self.stuck_spool_retry_start_time: Optional[float] = None
+        self.stuck_spool_retry_forward_direction: int = 1
+        self.stuck_spool_retry_timer: Optional[Any] = None
+        self.stuck_spool_retry_encoder_start: Optional[int] = None
+        self.stuck_spool_retry_forced: bool = False
 
         # Clog detection
         self.clog_active: bool = False
@@ -334,6 +344,18 @@ class FPSState:
         if not preserve_restore:
             self.stuck_spool_restore_follower = False
             self.stuck_spool_restore_direction = 1
+        self.reset_stuck_spool_retry()
+
+    def reset_stuck_spool_retry(self) -> None:
+        """Reset automatic stuck spool recovery tracking."""
+        self.stuck_spool_retry_attempted = False
+        self.stuck_spool_retry_active = False
+        self.stuck_spool_retry_start_time = None
+        self.stuck_spool_retry_forward_direction = 1
+        self.stuck_spool_retry_timer = None
+        self.stuck_spool_retry_encoder_start = None
+        self.stuck_spool_retry_forced = False
+        self.encoder_samples.clear()
 
     def reset_clog_tracker(self) -> None:
         """Reset clog detection telemetry so monitoring restarts fresh."""
@@ -510,7 +532,7 @@ class OAMSManager:
             ):
                 fps_state.state_name = FPSLoadState.LOADED
                 fps_state.since = self.reactor.monotonic()
-                fps_state.reset_stuck_spool_state()
+                self._reset_fps_stuck_spool_state(fps_state)
                 fps_state.reset_clog_tracker()
                 self._ensure_forward_follower(
                     fps_name,
@@ -519,7 +541,7 @@ class OAMSManager:
                 )
             else:
                 fps_state.state_name = FPSLoadState.UNLOADED
-                fps_state.reset_stuck_spool_state()
+                self._reset_fps_stuck_spool_state(fps_state)
                 fps_state.reset_clog_tracker()
                 self._cancel_post_load_pressure_check(fps_state)
         
@@ -636,7 +658,7 @@ class OAMSManager:
             self.stop_monitors()
         for (fps_name, fps_state) in self.current_state.fps_state.items():
             fps_state.encoder_samples.clear()
-            fps_state.reset_stuck_spool_state()
+            self._reset_fps_stuck_spool_state(fps_state)
             self._cancel_post_load_pressure_check(fps_state)
 
         for oams_name, oam in self.oams.items():
@@ -1125,7 +1147,7 @@ class OAMSManager:
             fps_state.current_spool_idx = None
             fps_state.since = self.reactor.monotonic()
             self.current_group = None
-            fps_state.reset_stuck_spool_state()
+            self._reset_fps_stuck_spool_state(fps_state)
 
             fps_state.reset_clog_tracker()
 
@@ -1139,6 +1161,8 @@ class OAMSManager:
             fps_state.since = self.reactor.monotonic()
             fps_state.current_oams = oams.name
             fps_state.current_spool_idx = oams.current_spool
+            fps_state.direction = 0
+            self._reset_fps_stuck_spool_retry(fps_state)
         except Exception:
             logging.exception(
                 "OAMS: Failed to capture unload state for %s", fps_name
@@ -1161,7 +1185,7 @@ class OAMSManager:
             fps_state.current_group = None
             fps_state.current_spool_idx = None
             self.current_group = None
-            fps_state.reset_stuck_spool_state()
+            self._reset_fps_stuck_spool_state(fps_state)
 
             fps_state.reset_clog_tracker()
 
@@ -1200,11 +1224,13 @@ class OAMSManager:
                 continue
 
             try:
+                self._reset_fps_stuck_spool_retry(fps_state)
                 fps_state.state_name = FPSLoadState.LOADING
                 fps_state.encoder = oam.encoder_clicks
                 fps_state.since = self.reactor.monotonic()
                 fps_state.current_oams = oam.name
                 fps_state.current_spool_idx = bay_index
+                fps_state.direction = 1
             except Exception:
                 logging.exception(
                     "OAMS: Failed to capture load state for group %s bay %s",
@@ -1235,7 +1261,7 @@ class OAMSManager:
                 fps_state.since = self.reactor.monotonic()
                 fps_state.direction = 1
                 self.current_group = group_name
-                fps_state.reset_stuck_spool_state()
+                self._reset_fps_stuck_spool_state(fps_state)
 
                 fps_state.reset_clog_tracker()
 
@@ -1255,7 +1281,7 @@ class OAMSManager:
             fps_state.current_oams = None
 
             fps_state.following = False
-            fps_state.reset_stuck_spool_state()
+            self._reset_fps_stuck_spool_state(fps_state)
             fps_state.reset_clog_tracker()
 
             self._cancel_post_load_pressure_check(fps_state)
@@ -1352,6 +1378,32 @@ class OAMSManager:
                 logging.exception("OAMS: Failed to cancel post-load pressure timer")
         fps_state.post_load_pressure_timer = None
         fps_state.post_load_pressure_start = None
+
+    def _cancel_stuck_spool_retry_timer(self, fps_state: "FPSState") -> None:
+        """Stop the pending stuck spool recovery completion timer, if any."""
+        timer = getattr(fps_state, "stuck_spool_retry_timer", None)
+        if timer is None:
+            return
+        try:
+            self.reactor.unregister_timer(timer)
+        except Exception:
+            logging.exception("OAMS: Failed to cancel stuck spool recovery timer")
+        fps_state.stuck_spool_retry_timer = None
+
+    def _reset_fps_stuck_spool_retry(self, fps_state: "FPSState") -> None:
+        """Clear retry metadata and cancel any pending recovery timer."""
+        self._cancel_stuck_spool_retry_timer(fps_state)
+        fps_state.reset_stuck_spool_retry()
+
+    def _reset_fps_stuck_spool_state(
+        self,
+        fps_state: "FPSState",
+        *,
+        preserve_restore: bool = False,
+    ) -> None:
+        """Clear latched stuck spool state and any scheduled recovery timer."""
+        self._cancel_stuck_spool_retry_timer(fps_state)
+        fps_state.reset_stuck_spool_state(preserve_restore=preserve_restore)
 
     def _schedule_post_load_pressure_check(
         self,
@@ -1532,6 +1584,226 @@ class OAMSManager:
             )
 
 
+    def _attempt_stuck_spool_recovery(
+        self,
+        fps_name: str,
+        fps_state: "FPSState",
+        oams: Optional[Any],
+    ) -> bool:
+        """Attempt to free a stuck spool by briefly reversing the follower."""
+        if fps_state.current_spool_idx is None:
+            return False
+
+        if oams is None and fps_state.current_oams is not None:
+            oams = self.oams.get(fps_state.current_oams)
+        if oams is None:
+            return False
+
+        if fps_state.stuck_spool_retry_attempted or fps_state.stuck_spool_retry_active:
+            return False
+
+        self._cancel_stuck_spool_retry_timer(fps_state)
+
+        forward_direction = fps_state.direction if fps_state.direction in (0, 1) else 1
+        reverse_direction = 0 if forward_direction == 1 else 1
+
+        spool_idx = fps_state.current_spool_idx
+
+        fps_state.encoder_samples.clear()
+
+        try:
+            oams.set_oams_follower(0, forward_direction)
+        except Exception:
+            logging.exception(
+                "OAMS: Failed to stop follower before stuck spool recovery on %s spool %s",
+                fps_name,
+                spool_idx,
+            )
+        fps_state.following = False
+        fps_state.direction = forward_direction
+
+        if STUCK_SPOOL_RECOVERY_SETTLE_TIME > 0:
+            try:
+                self.reactor.pause(
+                    self.reactor.monotonic() + STUCK_SPOOL_RECOVERY_SETTLE_TIME
+                )
+            except Exception:
+                logging.exception(
+                    "OAMS: Failed to pause before reversing follower on %s spool %s",
+                    fps_name,
+                    spool_idx,
+                )
+
+        encoder_start = None
+        try:
+            encoder_start = oams.encoder_clicks
+        except Exception:
+            logging.exception(
+                "OAMS: Failed to sample encoder before stuck spool recovery on %s spool %s",
+                fps_name,
+                spool_idx,
+            )
+
+        try:
+            oams.set_oams_follower(1, reverse_direction)
+        except Exception:
+            logging.exception(
+                "OAMS: Failed to reverse follower for stuck spool recovery on %s spool %s",
+                fps_name,
+                spool_idx,
+            )
+            fps_state.following = False
+            fps_state.direction = forward_direction
+            fps_state.stuck_spool_retry_start_time = None
+            self._cancel_stuck_spool_retry_timer(fps_state)
+            # Allow a future recovery attempt since the reverse command failed.
+            fps_state.stuck_spool_retry_attempted = False
+            fps_state.stuck_spool_retry_encoder_start = None
+            fps_state.stuck_spool_retry_forced = False
+            self._enable_follower(
+                fps_name,
+                fps_state,
+                oams,
+                forward_direction,
+                "stuck spool recovery fallback",
+            )
+            return False
+
+        now = self.reactor.monotonic()
+
+        fps_state.stuck_spool_retry_attempted = True
+        fps_state.stuck_spool_retry_active = True
+        fps_state.stuck_spool_retry_forward_direction = forward_direction
+        fps_state.stuck_spool_retry_start_time = now
+        fps_state.following = True
+        fps_state.direction = reverse_direction
+        fps_state.stuck_spool_retry_encoder_start = encoder_start
+
+        try:
+            timer = self.reactor.register_timer(
+                partial(
+                    self._stuck_spool_recovery_timer_cb,
+                    fps_name,
+                    fps_state,
+                ),
+                now + STUCK_SPOOL_RECOVERY_REVERSE_TIME,
+            )
+            fps_state.stuck_spool_retry_timer = timer
+        except Exception:
+            fps_state.stuck_spool_retry_timer = None
+            logging.exception(
+                "OAMS: Failed to schedule stuck spool recovery completion for %s spool %s",
+                fps_name,
+                spool_idx,
+            )
+
+        logging.info(
+            "OAMS: Reversing follower for %s spool %s to clear suspected stuck spool for %.1fs.",
+            fps_name,
+            spool_idx,
+            STUCK_SPOOL_RECOVERY_REVERSE_TIME,
+        )
+        return True
+
+    def _stuck_spool_recovery_timer_cb(
+        self,
+        fps_name: str,
+        fps_state: "FPSState",
+        eventtime: float,
+    ) -> float:
+        """Timer callback to restore forward motion after reversing."""
+        fps_state.stuck_spool_retry_timer = None
+        oams = self.oams.get(fps_state.current_oams) if fps_state.current_oams else None
+        self._complete_stuck_spool_recovery(fps_name, fps_state, oams)
+        return self.reactor.NEVER
+
+    def _complete_stuck_spool_recovery(
+        self,
+        fps_name: str,
+        fps_state: "FPSState",
+        oams: Optional[Any],
+    ) -> None:
+        """Restore normal follower direction after a recovery attempt."""
+        self._cancel_stuck_spool_retry_timer(fps_state)
+        if not fps_state.stuck_spool_retry_active:
+            return
+
+        if oams is None and fps_state.current_oams is not None:
+            oams = self.oams.get(fps_state.current_oams)
+
+        if oams is None or fps_state.current_spool_idx is None:
+            self._reset_fps_stuck_spool_retry(fps_state)
+            return
+
+        forward_direction = fps_state.stuck_spool_retry_forward_direction
+        reverse_direction = 0 if forward_direction == 1 else 1
+        spool_idx = fps_state.current_spool_idx
+
+        try:
+            oams.set_oams_follower(0, reverse_direction)
+        except Exception:
+            logging.exception(
+                "OAMS: Failed to stop reverse follower after stuck spool recovery on %s spool %s",
+                fps_name,
+                spool_idx,
+            )
+
+        encoder_start = fps_state.stuck_spool_retry_encoder_start
+        encoder_end = None
+        try:
+            encoder_end = oams.encoder_clicks
+        except Exception:
+            logging.exception(
+                "OAMS: Failed to sample encoder after stuck spool recovery on %s spool %s",
+                fps_name,
+                spool_idx,
+            )
+
+        fps_state.following = False
+        fps_state.direction = forward_direction
+
+        self._enable_follower(
+            fps_name,
+            fps_state,
+            oams,
+            forward_direction,
+            "stuck spool recovery",
+        )
+
+        movement = None
+        if encoder_start is not None and encoder_end is not None:
+            movement = abs(encoder_end - encoder_start)
+            logging.info(
+                "OAMS: Stuck spool recovery for %s spool %s moved encoder by %d clicks.",
+                fps_name,
+                spool_idx,
+                movement,
+            )
+            if movement < MIN_ENCODER_DIFF:
+                if not fps_state.stuck_spool_retry_forced:
+                    logging.warning(
+                        "OAMS: Reverse follower on %s spool %s reported < %d encoder clicks; allowing one more retry.",
+                        fps_name,
+                        spool_idx,
+                        MIN_ENCODER_DIFF,
+                    )
+                    fps_state.stuck_spool_retry_attempted = False
+                    fps_state.stuck_spool_retry_forced = True
+                else:
+                    logging.warning(
+                        "OAMS: Reverse follower on %s spool %s still reported < %d encoder clicks after retry.",
+                        fps_name,
+                        spool_idx,
+                        MIN_ENCODER_DIFF,
+                    )
+            else:
+                fps_state.stuck_spool_retry_forced = False
+
+        fps_state.stuck_spool_retry_encoder_start = None
+        fps_state.stuck_spool_retry_active = False
+        fps_state.stuck_spool_retry_start_time = None
+        fps_state.encoder_samples.clear()
+
     def _handle_printing_resumed(self, _eventtime):
         """Re-enable any followers that were paused due to a stuck spool."""
         for fps_name, fps_state in self.current_state.fps_state.items():
@@ -1569,6 +1841,7 @@ class OAMSManager:
             return
 
         spool_idx = fps_state.current_spool_idx
+        self._reset_fps_stuck_spool_retry(fps_state)
         if oams is None and fps_state.current_oams is not None:
             oams = self.oams.get(fps_state.current_oams)
 
@@ -1617,6 +1890,19 @@ class OAMSManager:
                 and self.reactor.monotonic() - fps_state.since
                 > MONITOR_ENCODER_UNLOADING_SPEED_AFTER
             ):
+                if fps_state.stuck_spool_retry_active:
+                    now = self.reactor.monotonic()
+                    if (
+                        fps_state.stuck_spool_retry_start_time is None
+                        or now - fps_state.stuck_spool_retry_start_time
+                        >= STUCK_SPOOL_RECOVERY_REVERSE_TIME
+                    ):
+                        self._complete_stuck_spool_recovery(
+                            fps_name,
+                            fps_state,
+                            oams,
+                        )
+                    return eventtime + MONITOR_ENCODER_PERIOD
                 if oams is None:
                     return eventtime + MONITOR_ENCODER_PERIOD
                 try:
@@ -1641,19 +1927,28 @@ class OAMSManager:
                     encoder_diff,
                 )
                 if encoder_diff < MIN_ENCODER_DIFF:
-                    try:
-                        oams.set_led_error(fps_state.current_spool_idx, 1)
-                    except Exception:
-                        logging.exception(
-                            "OAMS: Failed to set unload LED on %s",
+                    if not fps_state.stuck_spool_retry_attempted:
+                        if self._attempt_stuck_spool_recovery(
                             fps_name,
+                            fps_state,
+                            oams,
+                        ):
+                            return eventtime + MONITOR_ENCODER_PERIOD
+                    if fps_state.stuck_spool_retry_active:
+                        return eventtime + MONITOR_ENCODER_PERIOD
+                    if fps_state.stuck_spool_retry_attempted:
+                        message = (
+                            "Printer paused because the unloading speed of the moving filament was too low"
                         )
-                    self._pause_printer_message(
-                        "Printer paused because the unloading speed of the moving filament was too low"
-                    )
-                    logging.info("after unload speed too low")
-                    self.stop_monitors()
-                    return self.printer.get_reactor().NEVER
+                        self._trigger_stuck_spool_pause(
+                            fps_name,
+                            fps_state,
+                            oams,
+                            message,
+                        )
+                        logging.info("after unload speed too low")
+                        self.stop_monitors()
+                        return self.printer.get_reactor().NEVER
             return eventtime + MONITOR_ENCODER_PERIOD
         return partial(_monitor_unload_speed, self)
     
@@ -1671,6 +1966,19 @@ class OAMSManager:
                 and self.reactor.monotonic() - fps_state.since
                 > MONITOR_ENCODER_LOADING_SPEED_AFTER
             ):
+                if fps_state.stuck_spool_retry_active:
+                    now = self.reactor.monotonic()
+                    if (
+                        fps_state.stuck_spool_retry_start_time is None
+                        or now - fps_state.stuck_spool_retry_start_time
+                        >= STUCK_SPOOL_RECOVERY_REVERSE_TIME
+                    ):
+                        self._complete_stuck_spool_recovery(
+                            fps_name,
+                            fps_state,
+                            oams,
+                        )
+                    return eventtime + MONITOR_ENCODER_PERIOD
                 if oams is None:
                     return eventtime + MONITOR_ENCODER_PERIOD
                 try:
@@ -1692,25 +2000,35 @@ class OAMSManager:
                     encoder_diff,
                 )
                 if encoder_diff < MIN_ENCODER_DIFF:
-                    group_label = fps_state.current_group or fps_name
-                    spool_label = (
-                        str(fps_state.current_spool_idx)
-                        if fps_state.current_spool_idx is not None
-                        else "unknown"
-                    )
-                    message = (
-                        "Spool appears stuck while loading"
-                        if fps_state.current_group is None
-                        else f"Spool appears stuck while loading {group_label} spool {spool_label}"
-                    )
-                    self._trigger_stuck_spool_pause(
-                        fps_name,
-                        fps_state,
-                        oams,
-                        message,
-                    )
-                    self.stop_monitors()
-                    return self.printer.get_reactor().NEVER
+                    if not fps_state.stuck_spool_retry_attempted:
+                        if self._attempt_stuck_spool_recovery(
+                            fps_name,
+                            fps_state,
+                            oams,
+                        ):
+                            return eventtime + MONITOR_ENCODER_PERIOD
+                    if fps_state.stuck_spool_retry_active:
+                        return eventtime + MONITOR_ENCODER_PERIOD
+                    if fps_state.stuck_spool_retry_attempted:
+                        group_label = fps_state.current_group or fps_name
+                        spool_label = (
+                            str(fps_state.current_spool_idx)
+                            if fps_state.current_spool_idx is not None
+                            else "unknown"
+                        )
+                        message = (
+                            "Spool appears stuck while loading"
+                            if fps_state.current_group is None
+                            else f"Spool appears stuck while loading {group_label} spool {spool_label}"
+                        )
+                        self._trigger_stuck_spool_pause(
+                            fps_name,
+                            fps_state,
+                            oams,
+                            message,
+                        )
+                        self.stop_monitors()
+                        return self.printer.get_reactor().NEVER
             return eventtime + MONITOR_ENCODER_PERIOD
         return partial(_monitor_load_speed, self)
 
@@ -1733,10 +2051,18 @@ class OAMSManager:
                                 "OAMS: Failed to clear stuck spool LED on %s while fps missing",
                                 fps_name,
                             )
-                fps_state.reset_stuck_spool_state()
+                self._reset_fps_stuck_spool_state(fps_state)
                 return eventtime + MONITOR_ENCODER_PERIOD
 
             if fps_state.state_name != FPSLoadState.LOADED:
+                if fps_state.state_name in (
+                    FPSLoadState.LOADING,
+                    FPSLoadState.UNLOADING,
+                ):
+                    # Allow the load/unload monitors to manage the stuck spool retry
+                    # lifecycle so the automatic recovery attempt can complete.
+                    return eventtime + MONITOR_ENCODER_PERIOD
+
                 if (
                     fps_state.stuck_spool_active
                     and fps_state.current_oams is not None
@@ -1751,7 +2077,7 @@ class OAMSManager:
                                 "OAMS: Failed to clear stuck spool LED on %s while not loaded",
                                 fps_name,
                             )
-                fps_state.reset_stuck_spool_state()
+                self._reset_fps_stuck_spool_state(fps_state)
                 return eventtime + MONITOR_ENCODER_PERIOD
 
             oams = None
@@ -1770,7 +2096,7 @@ class OAMSManager:
                             "OAMS: Failed to clear stuck spool LED on %s without active spool",
                             fps_name,
                         )
-                fps_state.reset_stuck_spool_state()
+                self._reset_fps_stuck_spool_state(fps_state)
                 return eventtime + MONITOR_ENCODER_PERIOD
 
             try:
@@ -1790,8 +2116,9 @@ class OAMSManager:
                             fps_name,
                         )
 
-                fps_state.reset_stuck_spool_state(
-                    preserve_restore=fps_state.stuck_spool_restore_follower
+                self._reset_fps_stuck_spool_state(
+                    fps_state,
+                    preserve_restore=fps_state.stuck_spool_restore_follower,
                 )
 
                 return eventtime + MONITOR_ENCODER_PERIOD
@@ -1806,8 +2133,9 @@ class OAMSManager:
                             fps_name,
                         )
 
-                fps_state.reset_stuck_spool_state(
-                    preserve_restore=fps_state.stuck_spool_restore_follower
+                self._reset_fps_stuck_spool_state(
+                    fps_state,
+                    preserve_restore=fps_state.stuck_spool_restore_follower,
                 )
 
                 return eventtime + MONITOR_ENCODER_PERIOD
@@ -1860,7 +2188,7 @@ class OAMSManager:
                         "stuck spool recovery",
                     )
                 if not fps_state.stuck_spool_restore_follower:
-                    fps_state.reset_stuck_spool_state()
+                    self._reset_fps_stuck_spool_state(fps_state)
 
 
             return eventtime + MONITOR_ENCODER_PERIOD


### PR DESCRIPTION
## Summary
- add a follower settle delay and extra stuck-spool retry bookkeeping to capture encoder movement during recovery attempts
- pause briefly before reversing the follower, remember the encoder baseline, and log the motion observed when the retry completes
- allow a single automatic reattempt when the follower reports no encoder movement so a failed reverse command does not immediately pause the printer

## Testing
- python -m compileall klipper_openams/src/oams_manager.py

------
https://chatgpt.com/codex/tasks/task_e_68de876410c88326a8c3ff0ea490bda6