### PR TITLE
Sync Spoolman loaded_lane extras with AFC spool assignments

### DIFF
--- a/AFC-Klipper-Add-On/extras/AFC_spool.py
+++ b/AFC-Klipper-Add-On/extras/AFC_spool.py
@@ -268,11 +268,88 @@ class AFCSpool:
         """
         Helper function for clearing out lane spool values
         """
+        previous_spool_id = cur_lane.spool_id
         cur_lane.spool_id = ''
         cur_lane.material = ''
         cur_lane.color = ''
         cur_lane.weight = 0
         cur_lane.extruder_temp = None
+        if self.afc.spoolman is not None and previous_spool_id:
+            self._clear_loaded_lane_extra(previous_spool_id)
+
+    def _get_lane_identifier(self, cur_lane):
+        lane_name = getattr(cur_lane, 'name', '')
+        digits = ''.join(ch for ch in lane_name if ch.isdigit())
+        return digits if digits else lane_name
+
+    def _normalize_spool_id(self, spool_id):
+        if spool_id in (None, '', 0):
+            return None
+        try:
+            return int(spool_id)
+        except (TypeError, ValueError):
+            self.logger.debug(f"Unable to convert spool id '{spool_id}' to int for loaded lane extra update")
+            return None
+
+    def _write_loaded_lane_extra(self, spool_id, lane_identifier, spool_data=None):
+        try:
+            if spool_data is None:
+                spool_data = self.afc.moonraker.get_spool(spool_id)
+            if spool_data is None:
+                return False
+            extras = dict(spool_data.get('extra') or {})
+            changed = False
+            if lane_identifier is None:
+                if extras.pop('loaded_lane', None) is not None:
+                    changed = True
+            else:
+                lane_identifier = str(lane_identifier)
+                if extras.get('loaded_lane') != lane_identifier:
+                    extras['loaded_lane'] = lane_identifier
+                    changed = True
+            if changed:
+                self.afc.moonraker.update_spool(spool_id, {'extra': extras})
+            return changed
+        except Exception as e:
+            self.logger.error(f"Failed to update loaded_lane extra for spool {spool_id}: {e}")
+            return False
+
+    def _clear_duplicate_loaded_lanes(self, active_spool_id, lane_identifier):
+        try:
+            spools = self.afc.moonraker.list_spools()
+        except Exception as e:
+            self.logger.error(f"Failed to list spools when clearing duplicate loaded_lane assignments: {e}")
+            return
+        if not spools:
+            return
+        for spool in spools:
+            other_id = self._normalize_spool_id(spool.get('id')) if isinstance(spool, dict) else None
+            if other_id is None or other_id == active_spool_id:
+                continue
+            extras = spool.get('extra') or {}
+            if extras.get('loaded_lane') == str(lane_identifier):
+                new_extras = dict(extras)
+                new_extras.pop('loaded_lane', None)
+                try:
+                    self.afc.moonraker.update_spool(other_id, {'extra': new_extras})
+                except Exception as e:
+                    self.logger.error(f"Failed to clear duplicate loaded_lane for spool {other_id}: {e}")
+
+    def _set_loaded_lane_extra(self, cur_lane, spool_id, spool_data=None):
+        lane_identifier = self._get_lane_identifier(cur_lane)
+        normalized_id = self._normalize_spool_id(spool_id)
+        if normalized_id is None or not lane_identifier:
+            return
+        if self._write_loaded_lane_extra(normalized_id, lane_identifier, spool_data):
+            self.logger.info(f"Spool {normalized_id} set to loaded lane {lane_identifier}")
+        self._clear_duplicate_loaded_lanes(normalized_id, lane_identifier)
+
+    def _clear_loaded_lane_extra(self, spool_id):
+        normalized_id = self._normalize_spool_id(spool_id)
+        if normalized_id is None:
+            return
+        if self._write_loaded_lane_extra(normalized_id, None):
+            self.logger.info(f"Cleared loaded lane extra for spool {normalized_id}")
 
     def set_spoolID(self, cur_lane, SpoolID, save_vars=True):
         if self.afc.spoolman is not None:
@@ -293,6 +370,8 @@ class AFCSpool:
                         cur_lane.color = '#{}'.format(self._get_filament_values(result['filament'], 'multi_color_hexes').split(",")[0])
                     else:
                         cur_lane.color = '#{}'.format(self._get_filament_values(result['filament'], 'color_hex'))
+
+                    self._set_loaded_lane_extra(cur_lane, SpoolID, result)
 
                 except Exception as e:
                     self.afc.error.AFC_error("Error when trying to get Spoolman data for ID:{}, Error: {}".format(SpoolID, e), False)

--- a/AFC-Klipper-Add-On/extras/AFC_utils.py
+++ b/AFC-Klipper-Add-On/extras/AFC_utils.py
@@ -307,12 +307,29 @@ class AFC_moonraker:
             "request_method": "GET",
             "path": f"/v1/spool/{id}"
         }
-        spool_url = urljoin(self.host, 'server/spoolman/proxy')
-        req = Request( spool_url, urlencode(request_payload).encode() )
-
-        resp = self._get_results(req)
-        if resp is not None:
-            resp = resp
-        else:
+        resp = self._spoolman_proxy(request_payload)
+        if resp is None:
             self.logger.info(f"SpoolID: {id} not found")
         return resp
+
+    def list_spools(self):
+        """Return all spools available in Spoolman."""
+        request_payload = {
+            "request_method": "GET",
+            "path": "/v1/spool"
+        }
+        return self._spoolman_proxy(request_payload)
+
+    def update_spool(self, spool_id: int, data: dict):
+        """Patch a spool entry in Spoolman with the provided payload."""
+        request_payload = {
+            "request_method": "PATCH",
+            "path": f"/v1/spool/{spool_id}",
+            "body": json.dumps(data)
+        }
+        return self._spoolman_proxy(request_payload)
+
+    def _spoolman_proxy(self, request_payload: dict):
+        spool_url = urljoin(self.host, 'server/spoolman/proxy')
+        req = Request(spool_url, urlencode(request_payload).encode())
+        return self._get_results(req)


### PR DESCRIPTION
## Summary
- update AFC spool handling to set or clear the Spoolman `loaded_lane` extra when lanes change
- ensure only one spool claims a given lane by clearing duplicates through the Moonraker proxy helpers
- add Moonraker helper utilities for listing and patching spools via the Spoolman proxy

## Testing
- python -m compileall AFC-Klipper-Add-On/extras/AFC_spool.py AFC-Klipper-Add-On/extras/AFC_utils.py

------
https://chatgpt.com/codex/tasks/task_e_68e583d4d2588326bc119f4ab1c8cb1d