### PR TITLE
Abort AMS load when stuck spool detected

### DIFF
--- a/klipper_openams/src/oams.py
+++ b/klipper_openams/src/oams.py
@@ -483,6 +483,22 @@ OAMS[%s]: current_spool=%s fps_value=%s f1s_hes_value_0=%d f1s_hes_value_1=%d f1
     def set_oams_follower(self, enable, direction):
         self.oams_follower_cmd.send([enable, direction])
 
+    def abort_current_action(self, code: int = OAMSOpCode.ERROR_KLIPPER_CALL) -> None:
+        """Abort any in-flight hardware action initiated by Klipper helpers."""
+
+        if self.action_status is None:
+            return
+
+        logging.warning(
+            "OAMS[%d]: Aborting current action %s with code %d",
+            self.oams_idx,
+            self.action_status,
+            code,
+        )
+        self.action_status_code = code
+        self.action_status_value = None
+        self.action_status = None
+
     cmd_OAMS_FOLLOWER_help = "Enable or disable follower and set its direction"
 
     def cmd_OAMS_FOLLOWER(self, gcmd):

--- a/klipper_openams/src/oams_manager.py
+++ b/klipper_openams/src/oams_manager.py
@@ -1600,6 +1600,16 @@ class OAMSManager:
             fps_state.following = False
 
 
+        if oams is not None:
+            try:
+                oams.abort_current_action()
+            except Exception:
+                logging.exception(
+                    "OAMS: Failed to abort active action for %s during stuck spool pause",
+                    fps_name,
+                )
+
+
         fps_state.stuck_spool_active = True
         fps_state.stuck_spool_start_time = None
 


### PR DESCRIPTION
## Summary
- add a helper on the OAMS driver to abort any in-flight load or unload action initiated from Klipper
- ensure the stuck spool handler aborts the active hardware action so the printer can pause cleanly instead of hanging

## Testing
- not run (hardware dependent)


------
https://chatgpt.com/codex/tasks/task_e_68e82b0720248326a99e57bb33b5167f