### PR TITLE
Fix follower state reset after runout coasting

### DIFF
--- a/klipper_openams/src/oams_manager.py
+++ b/klipper_openams/src/oams_manager.py
@@ -164,6 +164,12 @@ class OAMSRunoutMonitor:
                             "OAMS: Failed to stop follower while coasting on %s",
                             self.fps_name,
                         )
+                    finally:
+                        # Ensure internal follower state matches the hardware when we
+                        # intentionally stop it for coasting. Otherwise subsequent
+                        # calls to _ensure_forward_follower() think the follower is
+                        # still running and will not re-enable it.
+                        fps_state.following = False
                     self.bldc_clear_position = fps.extruder.last_position
                     self.runout_after_position = 0.0
                     self.state = OAMSRunoutState.COASTING


### PR DESCRIPTION
## Summary
- ensure the runout monitor updates the follower tracking flag when it stops the follower for coasting
- allow subsequent follower checks to re-enable the hardware as expected

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68eb0ecefd788326b2ae73dbe236a84b