### PR TITLE
Limit PRIME_LINES macro to first four tools

### DIFF
--- a/printer_data/config/AFC/prime_lines.cfg
+++ b/printer_data/config/AFC/prime_lines.cfg
@@ -31,11 +31,13 @@ gcode:
 
   # Figure out the required tools by which tools are preheating
   {% for tn in printer.toolchanger.tool_numbers %}
-    {% set extruder_id = "extruder" + tn|string if tn > 0 else "extruder" %}
-    
-    {% if printer[extruder_id].target >= printer.configfile.settings[extruder_id].min_extrude_temp %}
-      # {print_tools.append(tn)}
-      {% set corvisquire = print_tools.append(tn) %}
+    {% if tn <= 3 %}
+      {% set extruder_id = "extruder" + tn|string if tn > 0 else "extruder" %}
+
+      {% if printer[extruder_id].target >= printer.configfile.settings[extruder_id].min_extrude_temp %}
+        # {print_tools.append(tn)}
+        {% set corvisquire = print_tools.append(tn) %}
+      {% endif %}
     {% endif %}
   {% endfor %}
 
@@ -43,12 +45,12 @@ gcode:
   {% if params.INITIAL_TOOL is defined %}
     {% set initial_tool = params.INITIAL_TOOL|int %}
 
-    {% if print_tools|length > 1 %}
+    {% if initial_tool in print_tools and print_tools|length > 1 %}
       {% set snorlax = print_tools.pop(print_tools.index(initial_tool)) %}
       {print_tools.append(initial_tool)}
     {% endif %}
-  
-    {% if printer.toolchanger.tool_number != initial_tool and printer.toolchanger.tool_number != print_tools[0] and printer.toolchanger.tool_number in print_tools %}
+
+    {% if print_tools and printer.toolchanger.tool_number != initial_tool and printer.toolchanger.tool_number != print_tools[0] and printer.toolchanger.tool_number in print_tools %}
       {% set mimikyu = print_tools.pop(print_tools.index(printer.toolchanger.tool_number)) %}
       {% set bulbasaur = print_tools.insert(0, printer.toolchanger.tool_number) %}
     {% endif %}


### PR DESCRIPTION
## Summary
- skip priming setup for tool numbers greater than three
- guard initial tool reordering logic to avoid errors when ignored tools are selected

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ef95afe3988326a0a5731c8b587826